### PR TITLE
Removing w4x from rotation to 4 way mode.

### DIFF
--- a/src/restrictors/ServoStik.cpp
+++ b/src/restrictors/ServoStik.cpp
@@ -37,7 +37,7 @@ void ServoStik::rotate(const umap<string, Ways>& playersData) {
 	case Ways::w4:
 		LogDebug("Rotating " + getName() + " to 4 ways.");
 		data[3] = 0;
-		break;			
+		break;
 	default:
 		LogDebug("Rotating " + getName() + " to 8 ways.");
 		data[3] = 1;

--- a/src/restrictors/ServoStik.cpp
+++ b/src/restrictors/ServoStik.cpp
@@ -35,10 +35,9 @@ void ServoStik::rotate(const umap<string, Ways>& playersData) {
 	case Ways::w2:
 	case Ways::w2v:
 	case Ways::w4:
-	case Ways::w4x:
 		LogDebug("Rotating " + getName() + " to 4 ways.");
 		data[3] = 0;
-		break;
+		break;			
 	default:
 		LogDebug("Rotating " + getName() + " to 8 ways.");
 		data[3] = 1;


### PR DESCRIPTION
If the servo stick is rotated to 4 way mode when the game is a 4 way diagonal game like qbert, it will actually become impossible to hit the diagonals to play the game at all.  For 4 way diagonal games the servo stick must remain in 8 way mode.