### PR TITLE
45: Input Plugins trigger must be unique to the input source

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -288,7 +288,7 @@ AC_CONFIG_FILES([
 AC_OUTPUT
 
 dnl Dump the build configuration for the developer
-AC_MSG_RESULT([\n--------- build environment -----------
+AC_MSG_RESULT([--------- build environment -----------
 Program      : $PACKAGE_NAME
 Version      : $PACKAGE_VERSION
 WebSite      : $PACKAGE_URL

--- a/src/DataLoader.cpp
+++ b/src/DataLoader.cpp
@@ -495,18 +495,57 @@ Actor* DataLoader::createAnimation(umap<string, string>& actorData) {
 
 void DataLoader::processInput(Profile* profile, const string& file) {
 	XMLHelper inputFile(createFilename(INPUT_DIR + file), "Input");
-	umap<string, string> elementAttr = processNode(inputFile.getRoot());
-	Utility::checkAttributes(REQUIRED_PARAM_NAME_ONLY, elementAttr, file);
-	string inputName = elementAttr[PARAM_NAME];
+	umap<string, string> inputAttr = processNode(inputFile.getRoot());
+	Utility::checkAttributes(REQUIRED_PARAM_NAME_ONLY, inputAttr, file);
+	string inputName = inputAttr[PARAM_NAME];
+	// If plugin is not loaded, load it.
 	if (not inputHandlers.count(inputName))
 		inputHandlers.emplace(inputName, new InputHandler(inputName));
-	umap<string, Items*> inputMapTmp = processInputMap(inputFile.getRoot());
-	profile->addInput(inputHandlers[inputName]->createInput(file, elementAttr, inputMapTmp));
+	umap<string, Items*> inputMapTmp;
+	try {
+		// Check for multiple source inputs
+		auto listenEvents(processInputSources(inputName, inputFile.getRoot()));
+		inputAttr["listenEvents"] = Utility::implode(listenEvents, FIELD_SEPARATOR);
+		tinyxml2::XMLElement* mapsNode = inputFile.getRoot()->FirstChildElement("maps");
+		uint count = 0;
+		for (size_t c = 0; c < listenEvents.size(); ++c) {
+			// Check for listenEvents, at this point everything is sanitized.
+			for (; mapsNode; mapsNode = mapsNode->NextSiblingElement("maps")) {
+				umap<string, string> mapsNodeAttr = processNode(mapsNode);
+				Utility::checkAttributes({"source"}, mapsNodeAttr, listenEvents[c]);
+				if (mapsNodeAttr["source"] == listenEvents[c]) {
+					processInputMap(mapsNode, inputMapTmp, to_string(c));
+					break;
+				}
+			}
+		}
+	}
+	catch (...) {
+		// single source or malformed.
+		processInputMap(inputFile.getRoot(), inputMapTmp);
+	}
+	profile->addInput(inputHandlers[inputName]->createInput(file, inputAttr, inputMapTmp));
 }
 
-umap<string, Items*> DataLoader::processInputMap(tinyxml2::XMLElement* inputNode) {
+vector<string> DataLoader::processInputSources(const string& inputName, tinyxml2::XMLElement* inputNode) {
+	// Check for listenEvents.
+	tinyxml2::XMLElement* listenEventsNode = inputNode->FirstChildElement("listenEvents");
+	if (not listenEventsNode) {
+		throw;
+	}
+	vector<string> listenEvents;
+	listenEventsNode = listenEventsNode->FirstChildElement("listenEvent");
+	for (; listenEventsNode; listenEventsNode = listenEventsNode->NextSiblingElement("listenEvent")) {
+		umap<string, string> listenEventsAttr = processNode(listenEventsNode);
+		Utility::checkAttributes(REQUIRED_PARAM_NAME_ONLY, listenEventsAttr, inputName);
+		listenEvents.push_back(listenEventsAttr[PARAM_NAME]);
+	}
+	if (listenEvents.empty())
+		throw;
+	return listenEvents;
+}
 
-	umap<string, Items*> itemsMap;
+void DataLoader::processInputMap(tinyxml2::XMLElement* inputNode, umap<string, Items*>& inputMaps, const string& id) {
 
 	tinyxml2::XMLElement* maps = inputNode->FirstChildElement("map");
 	for (; maps; maps = maps->NextSiblingElement("map")) {
@@ -518,15 +557,17 @@ umap<string, Items*> DataLoader::processInputMap(tinyxml2::XMLElement* inputNode
 				throw LEDError("Unknown Element " + elementAttr["target"] + " on map file");
 
 			// Check dupes and add
-			if (itemsMap.count(elementAttr["trigger"]) and itemsMap[elementAttr["trigger"]]->getName() == elementAttr["target"])
+			if (inputMaps.count(elementAttr["trigger"]) and inputMaps[elementAttr["trigger"]]->getName() == elementAttr["target"])
 				throw LEDError("Duplicated element map for " + elementAttr["target"] + " map " + elementAttr["value"]);
 
-			auto& e = allElements[elementAttr["target"]];
-			itemsMap.emplace(elementAttr["trigger"], new Element::Item(
+			auto e = allElements[elementAttr["target"]];
+			inputMaps.emplace(id + elementAttr["trigger"], new Element::Item(
 				e,
 				elementAttr.count(PARAM_COLOR) ? &Color::getColor(elementAttr[PARAM_COLOR]) : &e->getDefaultColor(),
-				Color::str2filter(elementAttr.count(PARAM_FILTER) ? elementAttr["filter"] : "Normal")
+				Color::str2filter(elementAttr.count(PARAM_FILTER) ? elementAttr["filter"] : "Normal"),
+				inputMaps.size()
 			));
+			continue;
 		}
 
 		if (elementAttr["type"] == "Group") {
@@ -534,18 +575,18 @@ umap<string, Items*> DataLoader::processInputMap(tinyxml2::XMLElement* inputNode
 				throw LEDError("Unknown Group " + elementAttr["target"] + " on map file");
 
 			// Check dupes and add
-			if (itemsMap.count(elementAttr["trigger"]) and itemsMap[elementAttr["trigger"]]->getName() == elementAttr["target"])
+			if (inputMaps.count(elementAttr["trigger"]) and inputMaps[elementAttr["trigger"]]->getName() == elementAttr["target"])
 				throw LEDError("Duplicated group map for " + elementAttr["target"] + " map " + elementAttr["trigger"]);
 
 			auto& g = layout.at(elementAttr["target"]);
-			itemsMap.emplace(elementAttr["trigger"], new Group::Item(
+			inputMaps.emplace(id + elementAttr["trigger"], new Group::Item(
 				&g,
 				elementAttr.count(PARAM_COLOR) ? &Color::getColor(elementAttr[PARAM_COLOR]) : &g.getDefaultColor(),
-				Color::str2filter(elementAttr.count(PARAM_FILTER) ? elementAttr["filter"] : "Normal")
+				Color::str2filter(elementAttr.count(PARAM_FILTER) ? elementAttr["filter"] : "Normal"),
+				inputMaps.size()
 			));
 		}
 	}
-	return itemsMap;
 }
 
 string DataLoader::createFilename(const string& name) {

--- a/src/DataLoader.hpp
+++ b/src/DataLoader.hpp
@@ -272,11 +272,22 @@ protected:
 	static Actor* createAnimation(umap<string, string>& actorData);
 
 	/**
-	 * Extracts input map data.
-	 * @param inputNode
-	 * @param input
+	 * Extract a list of input sources (listen events in the kernel)
+	 * @param inputName current input file
+	 * @param inputNode the input node
+	 * @return an array with the sources.
+	 * @throws exception if not found or is not valid.
 	 */
-	static umap<string, Items*> processInputMap(tinyxml2::XMLElement* inputNode);
+	static vector<string> processInputSources(const string& inputName, tinyxml2::XMLElement* inputNode);
+
+	/**
+	 * Decorates input map data.
+	 * @param inputNode XML node from where the maps will be extracted
+	 * @param inputMap where the new maps will be stored.
+	 * @param id only used to differentiate sources.
+	 * @return
+	 */
+	static void processInputMap(tinyxml2::XMLElement* inputNode, umap<string, Items*>& inputMaps, const string& id = "");
 
 	/**
 	 * Prepares the filenames.

--- a/src/animations/StepActor.hpp
+++ b/src/animations/StepActor.hpp
@@ -20,10 +20,10 @@
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "DirectionActor.hpp"
+
 #ifndef STEPACTOR_HPP_
 #define STEPACTOR_HPP_ 1
-
-#include "DirectionActor.hpp"
 
 namespace LEDSpicer::Animations {
 

--- a/src/devices/Adalight/README.md
+++ b/src/devices/Adalight/README.md
@@ -11,3 +11,7 @@ you are then left with a wifi + usb controlled led strip.
 
 What I do next is create a preset with leds ON but black and set it as the wled boot preset.
 When I'm ok with the settings (RGB order and max brightness mostly) and the strip is properly tested I disable the wifi (it forces you to reflash wled if you have to change something)
+
+## Adalight protocol
+
+https://www.partsnotincluded.com/visualizing-adalight-header-information/

--- a/src/devices/Element.hpp
+++ b/src/devices/Element.hpp
@@ -45,14 +45,19 @@ namespace LEDSpicer::Devices {
  */
 struct Items {
 
+	/// Stores the position in a list if necessary.
+	uint pos = 0;
+
+	/// Stores the desired color.
 	const Color* color = nullptr;
 
+	/// Stores the filter to be used when applying the color.
 	Color::Filters filter = Color::Filters::Normal;
 
 	Items() = default;
-	Items(const Color* color, Color::Filters filter) : color(color), filter(filter) {}
-	Items(const Items& item)  : color(item.color), filter(item.filter) {}
-	Items(Items&& item) : color(std::move(item.color)), filter(std::move(item.filter)) {}
+	Items(const Color* color, Color::Filters filter, uint pos) : color(color), filter(filter), pos(pos) {}
+	Items(const Items& item)  : color(item.color), filter(item.filter), pos(item.pos) {}
+	Items(Items&& item) : color(std::move(item.color)), filter(std::move(item.filter)), pos(std::move(item.pos)) {}
 
 	virtual ~Items() = default;
 
@@ -114,16 +119,17 @@ public:
 
 		Item() = default;
 
-		Item(Element* element, const Color* color, Color::Filters filter) :
-			Items(color, filter),
+		Item(Element* element, const Color* color, Color::Filters filter, uint pos = 0) :
+			Items(color, filter, pos),
 			element(element) {}
 
 		Item(const Item& item) : Items(item), element(item.element) {}
 
 		Item& operator=(const Item& item) {
-			element   = item.element;
-			color     = item.color;
-			filter    = item.filter;
+			element = item.element;
+			color   = item.color;
+			filter  = item.filter;
+			pos     = item.pos;
 			return *this;
 		}
 

--- a/src/devices/Group.hpp
+++ b/src/devices/Group.hpp
@@ -53,8 +53,8 @@ public:
 
 		Item() = default;
 
-		Item(Group* group, const Color* color, Color::Filters filter) :
-			Items(color, filter),
+		Item(Group* group, const Color* color, Color::Filters filter, uint pos = 0) :
+			Items(color, filter, pos),
 			group(group) {}
 
 		Item(const Item& item) : Items(item), group(item.group) {}
@@ -62,9 +62,10 @@ public:
 		Item(Item&& item) : Items(item), group(std::move(item.group)) {}
 
 		Item& operator=(const Item& item) {
-			group     = item.group;
-			color     = item.color;
-			filter    = item.filter;
+			group  = item.group;
+			color  = item.color;
+			filter = item.filter;
+			pos    = item.pos;
 			return *this;
 		}
 

--- a/src/devices/Ultimarc/NanoLed.hpp
+++ b/src/devices/Ultimarc/NanoLed.hpp
@@ -6,10 +6,10 @@
  * @copyright Copyright © 2018 - 2024 Patricio A. Rossi (MeduZa)
  */
 
+#include "FF00SharedCode.hpp"
+
 #ifndef NANOLED_HPP_
 #define NANOLED_HPP_ 1
-
-#include "FF00SharedCode.hpp"
 
 #define NANO_LED_NAME       "Ultimarc NanoLed"
 #define NANO_LED_PRODUCT    0x1481

--- a/src/inputs/Actions.hpp
+++ b/src/inputs/Actions.hpp
@@ -20,11 +20,11 @@
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef ACTIONS_HPP_
-#define ACTIONS_HPP_ 1
-
 #include "utility/Speed.hpp"
 #include "Reader.hpp"
+
+#ifndef ACTIONS_HPP_
+#define ACTIONS_HPP_ 1
 
 namespace LEDSpicer::Inputs {
 
@@ -65,7 +65,7 @@ protected:
 
 		Record() = default;
 
-		Record(uint16_t map, bool active, Items* item, Record* next) :
+		Record(string map, bool active, Items* item, Record* next) :
 			map(map),
 			active(active),
 			item(item),
@@ -77,15 +77,16 @@ protected:
 			item(other.item),
 			next(other.next) {}
 
-		/// Key Map value.
-		uint16_t map = 0;
+		/// trigger map value.
+		string map = 0;
 
 		/// If true, the item is active.
 		bool active = false;
-		/// Element to turn on when called.
+
+		/// Element or Group to turn on when called.
 		Items* item = nullptr;
 
-		/// Next element on the list.
+		/// Next element or Group on the list.
 		Record* next = nullptr;
 	};
 
@@ -100,13 +101,13 @@ protected:
 	vector<vector<Record>> groupsMaps;
 
 	/// Small lookup table to avoid a loop every time we need to seek a value.
-	umap<uint16_t, LookupMap> groupMapLookup;
+	umap<string, LookupMap> groupMapLookup;
 
-	/// list of 1st elements for groups.
-	vector<uint16_t> firstItems;
+	/// list of the trigger of the first elements of each group.
+	vector<string> firstItems;
 
 	/// Elements or Groups blinking.
-	umap<uint16_t, Items*> blinkingItems;
+	umap<string, Items*> blinkingItems;
 
 	void blink();
 

--- a/src/inputs/Blinker.cpp
+++ b/src/inputs/Blinker.cpp
@@ -43,14 +43,13 @@ void Blinker::process() {
 		if (not event.value)
 			continue;
 
-		string codeName = std::to_string(event.code);
-		if (itemsMap.count(codeName)) {
-			LogDebug("key: " + codeName + " adds: " + to_string(times) + " times to element: " + itemsMap[codeName]->getName());
+		if (itemsMap.count(event.trigger)) {
+			LogDebug("key: " + event.trigger + " adds: " + to_string(times) + " times to element: " + itemsMap[event.trigger]->getName());
 			// switch
-			if (blinkingItems.count(event.code))
-				blinkingItems[event.code].times = 0;
+			if (blinkingItems.count(event.trigger))
+				blinkingItems[event.trigger].times = 0;
 			else
-				blinkingItems.emplace(event.code, Times{itemsMap[codeName], 0});
+				blinkingItems.emplace(event.trigger, Times{itemsMap[event.trigger], 0});
 		}
 	}
 }
@@ -71,18 +70,17 @@ void Blinker::blink() {
 	if (frames == cframe) {
 		cframe = 0;
 		for (auto& i : blinkingItems) {
-			string name = std::to_string(i.first);
 			// deactivate after time passed.
 			if (i.second.times == times) {
-				controlledItems->erase(name);
+				controlledItems->erase(i.first);
 				itemsToClean.push_back(i.first);
 				continue;
 			}
 			if (on) {
-				controlledItems->erase(name);
+				controlledItems->erase(i.first);
 			}
 			else {
-				controlledItems->emplace(name, i.second.item);
+				controlledItems->emplace(i.first, i.second.item);
 				++i.second.times;
 			}
 		}

--- a/src/inputs/Blinker.hpp
+++ b/src/inputs/Blinker.hpp
@@ -20,11 +20,13 @@
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "Reader.hpp"
+#include "utility/Speed.hpp"
+
 #ifndef BLINKER_HPP_
 #define BLINKER_HPP_ 1
 
-#include "Reader.hpp"
-#include "utility/Speed.hpp"
+#define DEFAULT_BLINKS "5"
 
 namespace LEDSpicer::Inputs {
 
@@ -39,7 +41,7 @@ public:
 		Reader(parameters, inputMaps),
 		Speed(parameters.count("speed") ? parameters["speed"] : ""),
 		frames(static_cast<uint8_t>(speed) * 3),
-		times(Utility::parseNumber(parameters.count("times") ? parameters["times"] : "", "Invalid numeric value ")) {}
+		times(Utility::parseNumber(parameters.count("times") ? parameters["times"] : DEFAULT_BLINKS, "Invalid numeric value ")) {}
 
 	virtual ~Blinker() = default;
 
@@ -63,9 +65,9 @@ protected:
 		uint8_t times = 0;
 	};
 
-	umap<uint16_t, Times> blinkingItems;
+	umap<string, Times> blinkingItems;
 
-	vector<uint16_t> itemsToClean;
+	vector<string> itemsToClean;
 
 	void blink();
 

--- a/src/inputs/Impulse.cpp
+++ b/src/inputs/Impulse.cpp
@@ -37,16 +37,15 @@ void Impulse::process() {
 		return;
 
 	for (auto& event : events) {
-		string codeName = std::to_string(event.code);
-		if (itemsMap.count(codeName)) {
-			if (controlledItems->count(codeName)) {
+		if (itemsMap.count(event.trigger)) {
+			if (controlledItems->count(event.trigger)) {
 				// released
 				if (not event.value)
-					controlledItems->erase(codeName);
+					controlledItems->erase(event.trigger);
 			}
 			else
 				// activated
-				controlledItems->emplace(codeName, itemsMap[codeName]);
+				controlledItems->emplace(event.trigger, itemsMap[event.trigger]);
 		}
 	}
 }

--- a/src/inputs/Impulse.hpp
+++ b/src/inputs/Impulse.hpp
@@ -20,10 +20,10 @@
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "Reader.hpp"
+
 #ifndef IMPULSE_HPP_
 #define IMPULSE_HPP_ 1
-
-#include "Reader.hpp"
 
 namespace LEDSpicer::Inputs {
 

--- a/src/inputs/Input.cpp
+++ b/src/inputs/Input.cpp
@@ -44,9 +44,9 @@ void Input::drawConfig() {
 	cout << "Elements and Groups mapping:" << endl;
 	for (auto& e : itemsMap)
 		cout <<
-			"Target: "  << e.second->getName() << endl <<
-			"Trigger: " << e.first << endl <<
-			"Color: "   << e.second->color->getName() << endl <<
+			"Target: "  << e.second->getName()                 << endl <<
+			"Trigger: " << e.first                             << endl <<
+			"Color: "   << e.second->color->getName()          << endl <<
 			"Filter: "  << Color::filter2str(e.second->filter) << endl << endl;
 }
 

--- a/src/inputs/Reader.hpp
+++ b/src/inputs/Reader.hpp
@@ -53,21 +53,33 @@ public:
 
 protected:
 
-	/// poll of events.
-	static vector<input_event> events;
+	struct ListenEventData {
+		int     rCode;
+		uint8_t index;
+	};
+
+	struct ReadData {
+		string trigger;
+		uint16_t type;
+		int value;
+	};
+
+	/// Detailed poll of events.
+	static vector<ReadData> events;
 
 	/// The first plugin will handle the reads.
 	static Input* readController;
 
 	/**
-	 * list of input device and their resource.
+	 * list of input device with their resource and index.
 	 */
-	static umap<string, int> listenEvents;
+	static umap<string, ListenEventData> listenEvents;
 
 	/**
 	 * Reads all the events.
 	 */
 	void readAll();
+
 };
 
 } /* namespace */

--- a/src/utility/Utility.cpp
+++ b/src/utility/Utility.cpp
@@ -93,6 +93,17 @@ vector<string> Utility::explode(const string& text, const char delimiter, const 
 	return temp;
 }
 
+string Utility::implode(const vector<string>& values, const char& delimiter) {
+	string r;
+	if (values.empty())
+		return r;
+	for (const string& s : values) {
+		r += s + delimiter;
+	}
+	r.resize(r.size() - 1);
+	return r;
+}
+
 string Utility::hex2str(int number) {
 	std::stringstream stream;
 	stream << std::hex << std::showbase << number;

--- a/src/utility/Utility.hpp
+++ b/src/utility/Utility.hpp
@@ -110,6 +110,14 @@ public:
 	);
 
 	/**
+	 * Merge an array into a string using a delimiter.
+	 * @param values
+	 * @param delimiter
+	 * @return
+	 */
+	static string implode(const vector<string>& values, const char& delimiter);
+
+	/**
 	 * Verify that a number is between two vales
 	 * @param val subject
 	 * @param min minimum


### PR DESCRIPTION
Task-Url: https://github.com/meduzapat/LEDSpicer/issues/45

* Now Reader (currently only multisource input plugin) uses a node to set the sources
* Multisource input plugins can group maps by source.
* Action plugin linked groups uses the map position rather than the trigger.
* Fixed some headers
* Added docs
* Updated all input plugins to the new format.
* Added new tools.