### PR TITLE
54: Allow sending parameters from emitter to ledspicer

### DIFF
--- a/src/DataLoader.hpp
+++ b/src/DataLoader.hpp
@@ -23,13 +23,13 @@
 // To handle daemonization and uid/gid.
 #include <unistd.h>
 
-#include <algorithm>
-
 #include <chrono>
 using std::chrono::milliseconds;
 #include <thread>
 
 #include "config.h"
+
+#include "Messages.hpp"
 #include "utility/XMLHelper.hpp"
 #include "utility/Color.hpp"
 #include "devices/Profile.hpp"
@@ -144,6 +144,15 @@ public:
 	void readConfiguration();
 
 	/**
+	 * Check if a profile exists in the cache.
+	 *
+	 * Does cache clean up when a reload is forced.
+	 * @param name
+	 * @return the profile or nullptr
+	 */
+	static Profile* getProfileFromCache(const string& name);
+
+	/**
 	 * Reads a profile file form disk or cache.
 	 * @param name
 	 * @param extra, if set will use it to differentiate from other profiles with the same name, only used while crafting profiles.
@@ -152,7 +161,10 @@ public:
 
 	/**
 	 * Reads an animation file.
-	 * @param file
+	 *
+	 * @param file the file name to load
+	 * @param extra used to differentiate between normal animations and modified animations like transitions.
+	 * @return
 	 */
 	static vector<Actor*> processAnimation(const string& file, const string& extra = "");
 
@@ -181,6 +193,11 @@ public:
 	 */
 	static void setInterval(uint8_t waitTime);
 
+	/**
+	 * Deletes all cached objects.
+	 */
+	static void destroyCache();
+
 /* Storage */
 
 	/// list with all elements by name.
@@ -194,12 +211,6 @@ public:
 
 	/// Stores the default profile name.
 	static Profile* defaultProfile;
-
-	/// Keeps references to profiles.
-	static umap<string, Profile*> profilesCache;
-
-	/// Keeps references to actors.
-	static umap<string, vector<Actor*>> animationCache;
 
 	/// Port number to use for listening.
 	static string portNumber;
@@ -222,9 +233,21 @@ public:
 	/// Keeps the milliseconds to wait.
 	static milliseconds waitTime;
 
+	/// Current active flags.
+	static uint8_t flags;
+
 protected:
 
 	static Modes mode;
+
+	/// Keeps references to profiles.
+	static umap<string, Profile*> profilesCache;
+
+	/// Keeps references to actors (handled in actor handlers).
+	static umap<string, vector<Actor*>> animationCache;
+
+	/// Keeps references to inputs (handled in input handlers).
+	static umap<string, Input*> inputCache;
 
 	/**
 	 * Loads the color File

--- a/src/Emitter.hpp
+++ b/src/Emitter.hpp
@@ -131,6 +131,13 @@ struct GameRecord {
  */
 int main(int argc, char **argv);
 
+/**
+ * Return the next parameter.
+ * @param argv
+ * @return
+ */
+string getNext(int index, int total, char **argv);
+
 GameRecord parseMameDataFile(const string& rom);
 GameRecord parseMame(const string& rom);
 GameRecord parseControlsIni(const string& rom);

--- a/src/Main.hpp
+++ b/src/Main.hpp
@@ -26,8 +26,6 @@
  */
 
 #include "MainBase.hpp"
-using std::chrono::high_resolution_clock;
-using std::chrono::duration_cast;
 
 #ifndef MAIN_HPP_
 #define MAIN_HPP_ 1
@@ -60,16 +58,6 @@ public:
 	 */
 	static void terminate();
 
-	/**
-	 * terminates the current profile and reset everything.
-	 */
-	void terminateCurrentProfile();
-
-protected:
-
-	static high_resolution_clock::time_point start;
-
-	void sendData();
 };
 
 /**

--- a/src/MainBase.hpp
+++ b/src/MainBase.hpp
@@ -24,7 +24,6 @@
 #include <csignal>
 using std::signal;
 
-#include "Messages.hpp"
 #include "DataLoader.hpp"
 #include "devices/DeviceUSB.hpp"
 
@@ -32,6 +31,10 @@ using std::signal;
 #define MAINBASE_HPP_ 1
 
 namespace LEDSpicer {
+
+using std::chrono::high_resolution_clock;
+using std::chrono::duration_cast;
+
 
 /**
  * LEDSpicer::MainBase
@@ -92,6 +95,9 @@ protected:
 	/// Keeps a list of always on groups for the current profile.
 	static umap<string, Group::Item> alwaysOnGroups;
 
+	/// Starting point for the frame.
+	static high_resolution_clock::time_point start;
+
 	/**
 	 * Functionality for test programs.
 	 * @return
@@ -112,6 +118,15 @@ protected:
 	 */
 	Profile* craftProfile(const string& name, const string& elements, const string& groups);
 
+	/**
+	 * Terminates the current profile and reset everything.
+	 */
+	void terminateCurrentProfile();
+
+	/**
+	 * Send data to all devices.
+	 */
+	void sendData();
 };
 
 } /* namespace LEDSpicer */

--- a/src/Message.cpp
+++ b/src/Message.cpp
@@ -28,10 +28,14 @@ string Message::toString() {
 	string ret;
 	for (auto& s : data)
 		ret.append(s).push_back(RECORD_SEPARATOR);
+	ret.append(to_string(flags)).push_back(RECORD_SEPARATOR);
 	ret.append(to_string(static_cast<uint8_t>(type))).push_back('\0');
 	return ret;
 }
 
+string Message::toHumanString() {
+	return Utility::implode(data, ID_GROUP_SEPARATOR);
+}
 
 string Message::type2str(Types type) {
 	switch (type) {
@@ -87,6 +91,52 @@ Message::Types Message::str2type(const string& type) {
 	throw Error("Invalid type " + type);
 }
 
+string Message::flag2str(uint8_t flags) {
+	vector<string> result;
+	if (flags & FLAG_NO_ANIMATIONS)
+		result.push_back("NO_ANIMATIONS");
+	if (flags & FLAG_NO_INPUTS)
+		result.push_back("NO_INPUTS");
+	if (flags & FLAG_NO_START_TRANSITIONS)
+		result.push_back("NO_START_TRANSITIONS");
+	if (flags & FLAG_NO_END_TRANSITIONS)
+		result.push_back("NO_END_TRANSITIONS");
+	if (flags & FLAG_NO_ROTATOR)
+		result.push_back("NO_ROTATOR");
+	if (flags & FLAG_FORCE_RELOAD)
+		result.push_back("FORCE_RELOAD");
+	if (flags & FLAG_REPLACE)
+		result.push_back("REPLACE");
+	return Utility::implode(result, ' ');
+}
+
+void Message::str2flag(uint8_t& currentFlags, const string& flags) {
+	auto parts = Utility::explode(flags, '|');
+	bool rotator = false;
+	for (auto& flag : parts) {
+		if (flag == "NO_ANIMATIONS")
+			currentFlags |= FLAG_NO_ANIMATIONS;
+		else if (flag == "NO_INPUTS")
+			currentFlags |= FLAG_NO_INPUTS;
+		else if (flag == "NO_START_TRANSITIONS")
+			currentFlags |= FLAG_NO_START_TRANSITIONS;
+		else if (flag == "NO_END_TRANSITIONS")
+			currentFlags |= FLAG_NO_END_TRANSITIONS;
+		else if (flag == "NO_TRANSITIONS")
+			currentFlags |= FLAG_NO_START_TRANSITIONS | FLAG_NO_END_TRANSITIONS;
+		else if (flag == "NO_ROTATOR")
+			currentFlags |= FLAG_NO_ROTATOR;
+		else if (flag == "SHOW_ROTATOR")
+			rotator = true;
+		else if (flag == "FORCE_RELOAD")
+			currentFlags |= FLAG_FORCE_RELOAD;
+		else if (flag == "REPLACE")
+			currentFlags |= FLAG_REPLACE;
+	}
+	if (rotator)
+		currentFlags &= ~FLAG_NO_ROTATOR;
+}
+
 const vector<string>& LEDSpicer::Message::getData() const {
 	return data;
 }
@@ -105,6 +155,14 @@ Message::Types Message::getType() const {
 
 void Message::setType(Types type) {
 	this->type = type;
+}
+
+const uint8_t Message::getFlags() const {
+	return flags;
+}
+
+void Message::setFlags(const uint8_t flags) {
+	this->flags = flags;
 }
 
 void Message::reset() {

--- a/src/Message.hpp
+++ b/src/Message.hpp
@@ -56,9 +56,15 @@ struct Message {
 
 	string toString();
 
+	string toHumanString();
+
 	static string type2str(Types type);
 
 	static Types str2type(const string& type);
+
+	static string flag2str(uint8_t flags);
+
+	static void str2flag(uint8_t& currentFlags, const string& flags);
 
 	const vector<string>& getData() const;
 
@@ -70,11 +76,17 @@ struct Message {
 
 	void setType(Types type);
 
+	const uint8_t getFlags() const;
+
+	void setFlags(const uint8_t flags);
+
 	void reset();
 
 protected:
 
 	Types type = Types::Invalid;
+
+	uint8_t flags = 0;
 
 	vector<string> data;
 };

--- a/src/Messages.cpp
+++ b/src/Messages.cpp
@@ -40,7 +40,9 @@ bool Messages::read() {
 		try {
 			msg.setType(static_cast<Message::Types>(std::stoi(chunks.back())));
 			if (msg.getType() == Message::Types::Invalid)
-				throw true;
+				throw;
+			chunks.pop_back();
+			msg.setFlags(std::stoi(chunks.back()));
 		}
 		catch (...) {
 			LogNotice("Invalid message type received");

--- a/src/animations/Actor.cpp
+++ b/src/animations/Actor.cpp
@@ -49,7 +49,7 @@ void Actor::draw() {
 		frame = 0;
 	affectAllElements();
 	calculateElements();
-	if (not affectedElements.empty())
+	if (not affectedElements.empty()) {
 		switch (filter) {
 		case Color::Filters::Mask: {
 			const Color& black = Color::getColor("Black");
@@ -60,6 +60,7 @@ void Actor::draw() {
 				changeElementColor(elIdx, black, Color::Filters::Normal, 100);
 			}
 		}}
+	}
 }
 
 void Actor::drawConfig() {

--- a/src/animations/Actor.hpp
+++ b/src/animations/Actor.hpp
@@ -226,12 +226,13 @@ private:
 		/// Times repeated.
 		repeated  = 0;
 
-};
-
 // The functions to create and destroy actors.
 #define actorFactory(plugin) \
-	extern "C" LEDSpicer::Animations::Actor* createActor(umap<string, string>& parameters, LEDSpicer::Devices::Group* const group) { return new plugin(parameters, group); } \
-	extern "C" void destroyActor(LEDSpicer::Animations::Actor* instance) { delete instance; }
+	extern "C" Actor* createActor(umap<string, string>& parameters, LEDSpicer::Devices::Group* const group) { return new plugin(parameters, group); } \
+	extern "C" void destroyActor(Actor* instance) { delete instance; }
+
+};
+
 
 } /* namespace */
 

--- a/src/animations/Gradient.cpp
+++ b/src/animations/Gradient.cpp
@@ -38,20 +38,15 @@ Gradient::Gradient(umap<string, string>& parameters, Group* const group) :
 	// More speed less tones.
 	setTotalStepFrames(static_cast<float>(speed));
 
-	float
-		percent   = 0,
-		increment = 100.0 / tones;
+	float increment = (100.0 / tones) - 0.01;
 
 	// Pre-calculate colors.
-	uint8_t lastColor = colors.size() - 1, nextColor;
+	uint8_t lastColor = colors.size() -1, nextColor;
 	for (size_t color = 0; color < lastColor; ++color) {
 		nextColor = color + 1;
-		percent = 0;
-		for (uint8_t tone = 0; tone < tones; ++tone) {
+		for (float percent = increment; percent < 100; percent += increment) {
 			precalc.push_back(colors[color]->transition(*colors[nextColor], percent));
-			percent += increment;
 		}
-
 	}
 	// Return the colors to its normal shape, colors are only necessary for Draws().
 	colors.pop_back();
@@ -91,8 +86,8 @@ Gradient::Modes Gradient::str2mode(const string& mode) {
 		return Modes::All;
 	if (mode == "Cyclic")
 		return Modes::Cyclic;
-	LogError("Invalid mode " + mode + " assuming All");
-	return Modes::All;
+	LogError("Invalid mode " + mode + " assuming Cyclic");
+	return Modes::Cyclic;
 }
 
 string Gradient::mode2str(Modes mode) {

--- a/src/animations/Pulse.cpp
+++ b/src/animations/Pulse.cpp
@@ -68,5 +68,6 @@ Pulse::Modes Pulse::str2mode(const string& mode) {
 }
 
 void Pulse::restart() {
-	reset();
+	Colorful::reset();
+	DirectionActor::restart();
 }

--- a/src/devices/Adalight/Adalight.hpp
+++ b/src/devices/Adalight/Adalight.hpp
@@ -58,8 +58,9 @@ protected:
 	void detectPort() override;
 };
 
+deviceFactory(Adalight)
+
 } /* namespace */
 
-deviceFactory(LEDSpicer::Devices::Adalight::Adalight)
 
 #endif /* ADALIGHT_HPP_ */

--- a/src/devices/Device.hpp
+++ b/src/devices/Device.hpp
@@ -175,8 +175,8 @@ protected:
 
 // The functions to create and destroy devices.
 #define deviceFactory(plugin) \
-	extern "C" LEDSpicer::Devices::Device* createDevice(umap<string, string>& options) { return new plugin(options); } \
-	extern "C" void destroyDevice(LEDSpicer::Devices::Device* instance) { delete instance; }
+	extern "C" Device* createDevice(umap<string, string>& options) { return new plugin(options); } \
+	extern "C" void destroyDevice(Device* instance) { delete instance; }
 
 } /* namespace */
 

--- a/src/devices/GroovyGameGear/LedWiz32.hpp
+++ b/src/devices/GroovyGameGear/LedWiz32.hpp
@@ -72,8 +72,9 @@ protected:
 	void afterClaimInterface() override;
 };
 
+deviceFactory(LedWiz32)
+
 } /* namespace */
 
-deviceFactory(LEDSpicer::Devices::GroovyGameGear::LedWiz32)
 
 #endif /* LEDWIZ32_HPP_ */

--- a/src/devices/Profile.hpp
+++ b/src/devices/Profile.hpp
@@ -20,8 +20,6 @@
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "Element.hpp"
-#include "Group.hpp"
 #include "animations/FrameActor.hpp"
 #include "utility/Color.hpp"
 #include "inputs/Input.hpp"
@@ -112,11 +110,6 @@ public:
 	const Color& getBackgroundColor() const;
 
 	/**
-	 * @return the number of animations.
-	 */
-	uint8_t getAnimationsCount() const;
-
-	/**
 	 * @return the Profile name.
 	 */
 	const string& getName() const;
@@ -133,24 +126,33 @@ public:
 	 */
 	void addInput(Input* input);
 
+	/**
+	 * Sets the global flags pointer.
+	 * @param flags
+	 */
+	static void setGlobalFlags(uint8_t* flags);
+
 protected:
 
-	/// Color to use when cleaning up.
-	Color backgroundColor;
+	/// Current global flags.
+	static uint8_t* globalFlags;
 
 	/// Keeps the profile name.
 	string name;
 
+	/// Color to use when cleaning up.
+	Color backgroundColor;
+
 	/// What the profile is doing.
 	vector<Actor*>* currentActors;
 
-	/// List of animations by group to run.
+	/// List of animations to run.
 	vector<Actor*> animations;
 
-	/// List of animations by group to run at start.
+	/// List of animations to run at start.
 	vector<Actor*> startTransitions;
 
-	/// List of animations by group to run at end.
+	/// List of animations to run at end.
 	vector<Actor*> endTransitions;
 
 	/// Keeps a list of always on elements.

--- a/src/inputs/Input.hpp
+++ b/src/inputs/Input.hpp
@@ -94,8 +94,8 @@ protected:
 
 // The functions to create and destroy inputs.
 #define inputFactory(plugin) \
-	extern "C" LEDSpicer::Inputs::Input* createInput(umap<string, string>& parameters, umap<string, Items*>& inputMaps) {return new plugin(parameters, inputMaps);} \
-	extern "C" void destroyInput(LEDSpicer::Inputs::Input* instance) {delete instance;}
+	extern "C" Input* createInput(umap<string, string>& parameters, umap<string, Items*>& inputMaps) {return new plugin(parameters, inputMaps);} \
+	extern "C" void destroyInput(Input* instance) {delete instance;}
 
 } /* namespace */
 

--- a/src/utility/Utility.hpp
+++ b/src/utility/Utility.hpp
@@ -21,7 +21,7 @@
  */
 
 #include <cstdint>
-
+#include <algorithm>
 // To handle unordered map.
 #include <unordered_map>
 #ifndef umap
@@ -47,6 +47,28 @@ using std::vector;
 #define RECORD_SEPARATOR static_cast<char>(31)
 #define ID_SEPARATOR       ','
 #define ID_GROUP_SEPARATOR '|'
+#define WAYS_INDICATOR     "WAYS"
+
+/**
+ * Flags
+ * @{
+ */
+/// Flag indicating the absence of animations.
+#define FLAG_NO_ANIMATIONS        1
+/// Flag indicating the absence of inputs.
+#define FLAG_NO_INPUTS            2
+/// Flag indicating the absence of start transitions.
+#define FLAG_NO_START_TRANSITIONS 4
+/// Flag indicating the absence of end transitions.
+#define FLAG_NO_END_TRANSITIONS   8
+/// Flag indicating the absence of a rotator.
+#define FLAG_NO_ROTATOR           16
+/// Flag indicating a force reload.
+#define FLAG_FORCE_RELOAD         32
+/// Flag indicating a replacement.
+#define FLAG_REPLACE              64
+/// @}
+
 namespace LEDSpicer {
 
 class Utility {


### PR DESCRIPTION
Task-Url: https://github.com/meduzapat/LEDSpicer/issues/54

* Added flags to messages.
* Emitter can now send flags.
* LEDSpicerd will accept flags and change behavior accordingly.
* Always-on modifiers are now always displayed on top of animations but bellow inputs.
* Fixed issues with fallback profile loading.
* Resolved issues with the cache.
* Implemented cache for input plugins.
* Now everything loaded into caches can be reloaded.
* Fixed profile replacement.
* Addressed an issue with pulse not transitioning correctly.
* Gradient now defaults to cycles instead of all.
* Gradient is now smoother.
* Code cleanup.
* Complete rework of the replace parameter, now implemented as a flag, which fixes some flickering artifacts.