### PR TITLE
82: Cannot get Ledspicer to work with ServoStiks

### DIFF
--- a/src/Rotator.cpp
+++ b/src/Rotator.cpp
@@ -50,7 +50,7 @@ int main(int argc, char **argv) {
 
 	Log::initialize(true);
 
-	umap<string, Restrictor::Ways> playersData, availablePlayersData;
+	umap<string, Restrictor::Ways> playersRequestedData, availablePlayersData;
 
 	for (int i = 1; i < argc; i++) {
 
@@ -113,11 +113,11 @@ int main(int argc, char **argv) {
 			LogError("Invalid player data");
 			return EXIT_FAILURE;
 		}
-		playersData.emplace(commandline + "_" + argv[i + 1], Restrictor::str2ways(argv[i + 2]));
+		playersRequestedData.emplace(commandline + "_" + argv[i + 1], Restrictor::str2ways(argv[i + 2]));
 		i+=2;
 	}
 
-	if (playersData.empty() and resetWays.empty()) {
+	if (playersRequestedData.empty() and resetWays.empty()) {
 		LogError("Nothing to do");
 		return EXIT_SUCCESS;
 	}
@@ -148,58 +148,52 @@ int main(int argc, char **argv) {
 
 		for (; element; element = element->NextSiblingElement(RESTRICTOR)) {
 			umap<string, string> restrictorAttr(XMLHelper::processNode(element));
-			umap<string, uint8_t> playerData(std::move(processPlayerNode(element)));
-			if (playerData.empty())
+			umap<string, uint8_t> configPlayersData(std::move(processPlayerNode(element)));
+			if (configPlayersData.empty())
 				continue;
 			Utility::checkAttributes(REQUIRED_PARAM_RESTRICTOR, restrictorAttr, RESTRICTOR);
 			Restrictor* restrictor = nullptr;
 			if (restrictorAttr["name"] == ULTRASTIK_NAME) {
-				restrictor = new UltraStik360(restrictorAttr, playerData);
+				restrictor = new UltraStik360(restrictorAttr, configPlayersData);
 			}
 			else if (restrictorAttr["name"] == SERVOSTIK_NAME) {
-				restrictor = new ServoStik(restrictorAttr, playerData);
+				restrictor = new ServoStik(restrictorAttr, configPlayersData);
 			}
 			else if (restrictorAttr["name"] == GPWIZ49_NAME) {
-				restrictor = new GPWiz49(restrictorAttr, playerData);
+				restrictor = new GPWiz49(restrictorAttr, configPlayersData);
 			}
 			else if (restrictorAttr["name"] == GPWIZ40ROTOX_NAME) {
-				restrictor = new GPWiz40RotoX(restrictorAttr, playerData);
+				restrictor = new GPWiz40RotoX(restrictorAttr, configPlayersData);
 			}
 			else if (restrictorAttr["name"] == TOS428_NAME) {
-				restrictor = new TOS428(restrictorAttr, playerData);
+				restrictor = new TOS428(restrictorAttr, configPlayersData);
 			}
 			else {
 				LogError("Unknown hardware type " + restrictorAttr["name"]);
 				continue;
 			}
 
-			if (playerData.size() > restrictor->getMaxIds()) {
+			if (configPlayersData.size() > restrictor->getMaxIds()) {
 				LogDebug(restrictor->getFullName() + " supports only " + to_string(restrictor->getMaxIds()) + " devices");
 			}
 
-			for (const auto& pd : playerData) {
-				if (playersData.count(pd.first))
-					availablePlayersData.emplace(pd.first, playersData.at(pd.first));
-				else
-					LogDebug("This hardware type " + restrictorAttr["name"] + " does not support " + pd.first);
-			}
-
-			for (const auto& pd : playerData) {
-				if (playersData.count(pd.first))
-					availablePlayersData.emplace(pd.first, playersData.at(pd.first));
-				else
-					LogDebug("This hardware type " + restrictorAttr["name"] + " does not support " + pd.first);
+			for (const auto& pd : configPlayersData) {
+				// Set Rotations.
+				if (playersRequestedData.size() and playersRequestedData.count(pd.first)) {
+					availablePlayersData.emplace(pd.first, playersRequestedData.at(pd.first));
+				}
+				// Reset all.
+				else if (resetWays.size()) {
+					availablePlayersData.emplace(pd.first, Restrictor::str2ways(resetWays));
+				}
+				else {
+					LogDebug("This hardware type " + restrictor->getFullName() + " cannot handle " + pd.first);
+				}
 			}
 
 			restrictor->initialize();
-
-			if (resetWays.empty())
-				// Run Rotations.
-				restrictor->rotate(availablePlayersData);
-			else
-				// Reset all.
-				restrictor->rotate(Restrictor::str2ways(resetWays));
-
+			restrictor->rotate(availablePlayersData);
+			availablePlayersData.clear();
 			restrictor->terminate();
 			delete restrictor;
 		}

--- a/src/Rotator.cpp
+++ b/src/Rotator.cpp
@@ -187,15 +187,19 @@ int main(int argc, char **argv) {
 					availablePlayersData.emplace(pd.first, Restrictor::str2ways(resetWays));
 				}
 				else {
-					LogDebug("This hardware type " + restrictor->getFullName() + " cannot handle " + pd.first);
+					LogDebug(Restrictor::getProfileStr(pd.first) + " not requested for " + restrictor->getFullName());
 				}
 			}
 
+			if (availablePlayersData.empty()) {
+				continue;
+			}
 			restrictor->initialize();
 			restrictor->rotate(availablePlayersData);
 			availablePlayersData.clear();
 			restrictor->terminate();
 			delete restrictor;
+			std::this_thread::sleep_for(std::chrono::milliseconds(250));
 		}
 
 	}

--- a/src/devices/Ultimarc/PacDrive.cpp
+++ b/src/devices/Ultimarc/PacDrive.cpp
@@ -61,6 +61,6 @@ uint16_t PacDrive::getProduct() const {
 	return PAC_DRIVE_PRODUCT;
 }
 
-const bool PacDrive::productBasedId() const {
+const bool PacDrive::isProductBasedId() const {
 	return false;
 }

--- a/src/devices/Ultimarc/PacDrive.cpp
+++ b/src/devices/Ultimarc/PacDrive.cpp
@@ -61,36 +61,6 @@ uint16_t PacDrive::getProduct() const {
 	return PAC_DRIVE_PRODUCT;
 }
 
-void PacDrive::connect() {
-
-	LogInfo("Connecting to " + Utility::hex2str(getVendor()) + ":" + Utility::hex2str(getProduct()) + " " + getFullName());
-
-#ifdef DRY_RUN
-	LogDebug("No USB handle - DRY RUN");
-	return;
-#endif
-
-	libusb_device** list;
-	libusb_device* device;
-	libusb_get_device_list(usbSession, &list);
-	for (size_t idx = 0; list[idx] != nullptr; idx++) {
-		device = list[idx];
-		libusb_device_descriptor desc = {0};
-		libusb_get_device_descriptor(device, &desc);
-#ifdef DEVELOP
-		LogDebug("Found: Vendor-Device-bcdDevice = " + Utility::hex2str(desc.idVendor) + "-" + Utility::hex2str(desc.idProduct) + "-" + to_string(desc.bcdDevice));
-#endif
-		if (desc.idVendor == getVendor() and desc.idProduct == getProduct() and desc.bcdDevice == boardId)
-			break;
-		device = nullptr;
-	}
-	libusb_free_device_list(list, 1);
-
-	if (not device or libusb_open(device, &handle))
-		throw Error(
-			"Unable to connect to " +
-			Utility::hex2str(getVendor()) + ":" + Utility::hex2str(getProduct()) +
-			" " + getFullName()
-		);
-	libusb_set_auto_detach_kernel_driver(handle, true);
+const bool PacDrive::productBasedId() const {
+	return false;
 }

--- a/src/devices/Ultimarc/PacDrive.hpp
+++ b/src/devices/Ultimarc/PacDrive.hpp
@@ -62,7 +62,7 @@ public:
 
 	uint16_t getProduct() const override;
 
-	const bool productBasedId() const override;
+	const bool isProductBasedId() const override;
 
 protected:
 

--- a/src/devices/Ultimarc/PacDrive.hpp
+++ b/src/devices/Ultimarc/PacDrive.hpp
@@ -62,9 +62,9 @@ public:
 
 	uint16_t getProduct() const override;
 
-protected:
+	const bool productBasedId() const override;
 
-	void connect() override;
+protected:
 
 	void afterConnect() override {}
 };

--- a/src/restrictors/Restrictor.cpp
+++ b/src/restrictors/Restrictor.cpp
@@ -46,13 +46,6 @@ uint8_t Restrictor::getMaxIds() const {
 	return RESTRICTOR_SINGLE_ID;
 }
 
-void Restrictor::rotate(Ways ways) {
-	umap<string, Ways> playersData;
-	for (auto& p : players)
-		playersData.emplace(p.first, ways);
-	rotate(playersData);
-}
-
 Restrictor::Ways Restrictor::str2ways(const string& ways) {
 	if (ways == "1" or ways == "2" or ways == "strange2")
 		return Ways::w2;
@@ -105,7 +98,7 @@ string Restrictor::ways2str(Ways ways) {
 	return "";
 }
 
-Restrictor::Ways Restrictor::strWaysToWays(const std::string& strWays) {
+const Restrictor::Ways Restrictor::strWays2Ways(const std::string& strWays) {
 	try {
 		int intValue(std::stoi(strWays));
 		if (intValue >= static_cast<int>(Ways::invalid) && intValue <= static_cast<int>(Ways::rotary12)) {
@@ -118,7 +111,9 @@ Restrictor::Ways Restrictor::strWaysToWays(const std::string& strWays) {
 	}
 }
 
-string Restrictor::waysToStrWays(Ways ways) {
+const string Restrictor::ways2StrWays(Ways ways) {
+	if (ways == Ways::invalid)
+		return "invalid";
 	return to_string(static_cast<int>(ways));
 }
 

--- a/src/restrictors/Restrictor.cpp
+++ b/src/restrictors/Restrictor.cpp
@@ -120,3 +120,8 @@ const string Restrictor::ways2StrWays(Ways ways) {
 bool Restrictor::isRotary(const Ways& ways) {
 	return (ways == Ways::rotary8 or ways == Ways::rotary12);
 }
+
+const string Restrictor::getProfileStr(const string& profile) {
+	auto parts(Utility::explode(profile, '_'));
+	return "Player " + parts[0] + ", Joystick " + parts[1];
+}

--- a/src/restrictors/Restrictor.hpp
+++ b/src/restrictors/Restrictor.hpp
@@ -64,20 +64,14 @@ public:
 	virtual void rotate(const umap<string, Ways>& playersData) = 0;
 
 	/**
-	 * Rotate all players to this profile.
-	 * @param ways
-	 */
-	virtual void rotate(Ways ways);
-
-	/**
-	 * Convert strings into joystick positions.
+	 * Convert human readable strings into joystick positions.
 	 * @param ways
 	 * @return defaults to 8 ways.
 	 */
 	static Ways str2ways(const string& ways);
 
 	/**
-	 * Convert Ways into strings.
+	 * Convert Ways into human readable strings.
 	 * @param ways
 	 * @return
 	 */
@@ -88,14 +82,14 @@ public:
 	 * @param strWays
 	 * @return
 	 */
-	static Ways strWaysToWays(const std::string& strWays);
+	static const Ways strWays2Ways(const std::string& strWays);
 
 	/**
 	 * Converts ways into its string representation.
 	 * @param ways
 	 * @return
 	 */
-	static string waysToStrWays(Ways ways);
+	static const string ways2StrWays(Ways ways);
 
 	/**
 	 * @param ways

--- a/src/restrictors/Restrictor.hpp
+++ b/src/restrictors/Restrictor.hpp
@@ -97,6 +97,13 @@ public:
 	 */
 	static bool isRotary(const Ways& ways);
 
+	/**
+	 * Converts a profile into human readable.
+	 * @param profile like 1_1
+	 * @return a string like Player 1, Joystick 1
+	 */
+	static const string getProfileStr(const string& profile);
+
 protected:
 
 	/// Supported players for this restrictor in the form of P_J => id (player_joystick)

--- a/src/restrictors/ServoStik.cpp
+++ b/src/restrictors/ServoStik.cpp
@@ -64,11 +64,15 @@ uint16_t ServoStik::getVendor() const {
 }
 
 uint16_t ServoStik::getProduct() const {
-	return (SERVOSTIK_PRODUCT + getId() - 1);
+	return (SERVOSTIK_PRODUCT);
 }
 
 uint8_t ServoStik::getMaxIds() const {
 	return 2;
+}
+
+const bool ServoStik::productBasedId() const {
+	return false;
 }
 
 void ServoStik::storeWays(const string& profile, const string& ways) const {

--- a/src/restrictors/ServoStik.cpp
+++ b/src/restrictors/ServoStik.cpp
@@ -26,37 +26,57 @@ using namespace LEDSpicer::Restrictors;
 
 void ServoStik::rotate(const umap<string, Ways>& playersData) {
 
-
 	// ServoStik can move two restrictors to the same ways, pick the first and ignore the rest.
 	Ways way(playersData.begin()->second);
 	if (way == Ways::invalid)
 		return;
-
+	switch (way) {
+		case Ways::w2:
+		case Ways::w2v:
+		case Ways::w4:
+			way = Ways::w4;
+			break;
+		default:
+			way = Ways::w8;
+	}
 	string pd(playersData.begin()->first);
 
 	// Retrieve the previous state.
-	Ways prevState(strWaysToWays(retrieveWays(pd)));
+	Ways prevState(retrieveWays(pd));
 
 	// Check if the current state is different from the previous state
-	if (prevState == way)
+	if (prevState == way) {
+		LogDebug("Rotation not necessary for " + getFullName() + " already set to " + ways2str(prevState));
 		return;
+	}
 
 	vector<uint8_t> data {0, 0xdd, 0, 0};
-	switch (way) {
-	case Ways::w2:
-	case Ways::w2v:
-	case Ways::w4:
+	if (way == Ways::w4) {
 		LogDebug("Rotating " + getFullName() + " to 4 ways.");
 		data[3] = 0;
-		break;
-	default:
+	}
+	else {
 		LogDebug("Rotating " + getFullName() + " to 8 ways.");
 		data[3] = 1;
 	}
 	transferToConnection(data);
 
-	// Store the current state.
-	storeWays(pd, waysToStrWays(way));
+	// Store the current state for every config.
+	for (auto& pd: playersData) {
+		Ways way(pd.second);
+		switch (way) {
+			case Ways::invalid:
+				continue;
+			case Ways::w2:
+			case Ways::w2v:
+			case Ways::w4:
+				way = Ways::w4;
+				break;
+			default:
+				way = Ways::w8;
+		}
+		storeWays(pd.first, way);
+	}
 }
 
 uint16_t ServoStik::getVendor() const {
@@ -75,7 +95,7 @@ const bool ServoStik::isNonBasedId() const {
 	return true;
 }
 
-void ServoStik::storeWays(const string& profile, const string& ways) const {
+void ServoStik::storeWays(const string& profile, const Ways& ways) const {
 
 	string configDir = Utility::getConfigDir();
 	// Check if the directory exists, if not, create it
@@ -94,23 +114,25 @@ void ServoStik::storeWays(const string& profile, const string& ways) const {
 	string filePath(configDir + SERVOSTIK_DATA(profile));
 	std::ofstream outputFile(filePath);
 	if (outputFile.is_open()) {
-		LogDebug("File " + filePath + " stored " + ways);
-		outputFile << ways;
+		LogDebug("File " + filePath + " stored " + ways2str(ways));
+		outputFile << ways2StrWays(ways);
 		outputFile.close();
 		return;
 	}
 	LogDebug("Unable to save " + filePath);
 }
 
-const string ServoStik::retrieveWays(const string& profile) const {
+const Restrictor::Ways ServoStik::retrieveWays(const string& profile) const {
 	std::string filePath(Utility::getConfigDir() + SERVOSTIK_DATA(profile));
 	std::ifstream inputFile(filePath);
 	if (inputFile.is_open()) {
 		LogDebug("Reading " + filePath);
 		const string content((std::istreambuf_iterator<char>(inputFile)), std::istreambuf_iterator<char>());
+		const Ways way(strWays2Ways(content));
+		LogDebug("File " + filePath + " got " + ways2str(way));
 		inputFile.close();
-		return content;
+		return way;
 	}
 	LogDebug("Unable to read " + filePath);
-	return "";
+	return Ways::invalid;
 }

--- a/src/restrictors/ServoStik.cpp
+++ b/src/restrictors/ServoStik.cpp
@@ -71,8 +71,8 @@ uint8_t ServoStik::getMaxIds() const {
 	return 2;
 }
 
-const bool ServoStik::productBasedId() const {
-	return false;
+const bool ServoStik::isNonBasedId() const {
+	return true;
 }
 
 void ServoStik::storeWays(const string& profile, const string& ways) const {

--- a/src/restrictors/ServoStik.hpp
+++ b/src/restrictors/ServoStik.hpp
@@ -68,9 +68,9 @@ public:
 
 protected:
 
-	void storeWays(const string& profile, const string& ways) const;
+	void storeWays(const string& profile, const Ways& ways) const;
 
-	const string retrieveWays(const string& profile) const;
+	const Ways retrieveWays(const string& profile) const;
 
 };
 

--- a/src/restrictors/ServoStik.hpp
+++ b/src/restrictors/ServoStik.hpp
@@ -64,6 +64,8 @@ public:
 
 	uint8_t getMaxIds() const override;
 
+	const bool productBasedId() const override;
+
 protected:
 
 	void storeWays(const string& profile, const string& ways) const;

--- a/src/restrictors/ServoStik.hpp
+++ b/src/restrictors/ServoStik.hpp
@@ -64,7 +64,7 @@ public:
 
 	uint8_t getMaxIds() const override;
 
-	const bool productBasedId() const override;
+	const bool isNonBasedId() const override;
 
 protected:
 

--- a/src/utility/Serial.cpp
+++ b/src/utility/Serial.cpp
@@ -35,7 +35,11 @@ void Serial::detectPort() {
 void Serial::connect() {
 	if (port.empty()) {
 		LogDebug("Port is not defined attempting detection...");
+#ifdef DRY_RUN
+		LogDebug("No port detection - DRY RUN");
+#else
 		detectPort();
+#endif
 	}
 	LogDebug("Opening connection to " + port);
 #ifdef DRY_RUN

--- a/src/utility/USB.cpp
+++ b/src/utility/USB.cpp
@@ -66,7 +66,7 @@ USB::USB(uint16_t wValue, uint8_t  interface, uint8_t  boardId, uint8_t  maxBoar
 
 void USB::connect() {
 
-	LogInfo("Connecting to " + Utility::hex2str(getVendor()) + ":" + Utility::hex2str(getProduct()));
+	LogInfo("Connecting to " + Utility::hex2str(getVendor()) + ":" + Utility::hex2str(getProduct()) + " Id: " + to_string(boardId));
 
 #ifdef DRY_RUN
 	LogDebug("No USB handle - DRY RUN");
@@ -84,17 +84,25 @@ void USB::connect() {
 		libusb_device_descriptor desc = {0};
 		libusb_get_device_descriptor(device, &desc);
 
-		if (desc.idVendor == getVendor() and desc.idProduct == getProduct())
-			break;
+		if (desc.idVendor == getVendor() and desc.idProduct == getProduct()) {
+			// For ID by product only check the vendor and product.
+			if (productBasedId()) {
+				break;
+			}
+			// For independent hardware check device ID.
+			else if (desc.bcdDevice == boardId) {
+				break;
+			}
+
+		}
 		device = nullptr;
 	}
+	libusb_free_device_list(list, 1);
 
 	if (device and libusb_open(device, &handle) == LIBUSB_SUCCESS) {
 		libusb_set_auto_detach_kernel_driver(handle, true);
-		libusb_free_device_list(list, 1);
 		return;
 	}
-	libusb_free_device_list(list, 1);
 	throw Error("Failed to open device " + Utility::hex2str(getVendor()) + ":" + Utility::hex2str(getProduct()) + " id " + to_string(getId()));
 }
 
@@ -154,6 +162,10 @@ void USB::closeSession() {
 
 uint8_t USB::getId() const {
 	return boardId;
+}
+
+const bool USB::productBasedId() const {
+	return true;
 }
 
 int USB::send(vector<uint8_t>& data) const {

--- a/src/utility/USB.cpp
+++ b/src/utility/USB.cpp
@@ -86,14 +86,17 @@ void USB::connect() {
 
 		if (desc.idVendor == getVendor() and desc.idProduct == getProduct()) {
 			// For ID by product only check the vendor and product.
-			if (productBasedId()) {
+			if (isProductBasedId()) {
+				break;
+			}
+			// For hardware that have no order use the position on the list.
+			else if (isNonBasedId() and idx + 1 == boardId) {
 				break;
 			}
 			// For independent hardware check device ID.
 			else if (desc.bcdDevice == boardId) {
 				break;
 			}
-
 		}
 		device = nullptr;
 	}
@@ -164,8 +167,12 @@ uint8_t USB::getId() const {
 	return boardId;
 }
 
-const bool USB::productBasedId() const {
+const bool USB::isProductBasedId() const {
 	return true;
+}
+
+const bool USB::isNonBasedId() const {
+	return false;
 }
 
 int USB::send(vector<uint8_t>& data) const {

--- a/src/utility/USB.hpp
+++ b/src/utility/USB.hpp
@@ -70,6 +70,12 @@ public:
 	uint8_t getId() const;
 
 	/**
+	 * Returns true if the Board ID modifies the USB product code, false if not.
+	 * @return
+	 */
+	virtual const bool productBasedId() const;
+
+	/**
 	 * This function will be used to close the USB session,
 	 * need to be called only once when ledspicer exit.
 	 */

--- a/src/utility/USB.hpp
+++ b/src/utility/USB.hpp
@@ -73,7 +73,13 @@ public:
 	 * Returns true if the Board ID modifies the USB product code, false if not.
 	 * @return
 	 */
-	virtual const bool productBasedId() const;
+	virtual const bool isProductBasedId() const;
+
+	/**
+	 * Some hardware have no way to differentiate between the same product, so the ID will be the position on the USB list.
+	 * @return
+	 */
+	virtual const bool isNonBasedId() const;
 
 	/**
 	 * This function will be used to close the USB session,


### PR DESCRIPTION
Task-Url: https://github.com/meduzapat/LEDSpicer/issues/82

* Moved the connection code from pacdrive to USB, integrating both approaches.
* Added a new method to distinguish between Id based products and non-ID based products.
* Added Servostik to the non ID USB adapters.