### PR TITLE
95: Only one Servostik board works in multi-board setups

### DIFF
--- a/src/utilities/USB.hpp
+++ b/src/utilities/USB.hpp
@@ -109,10 +109,8 @@ protected:
 	uint16_t wValue = 0;
 
 	uint8_t
-		/// Interface number
-		interface = 0,
-		/// Board ID
-		boardId   = 0;
+		interface = 0, /// Interface number
+		boardId   = 0; /// Board ID (1 = 1st)
 
 	/// App wide libusb session.
 	static libusb_context *usbSession;


### PR DESCRIPTION
Task-Url: https://github.com/meduzapat/LEDSpicer/issues/95

Fix multi-device support for USB devices with identical VID/PID (ex: ServoStik)

- Sort matching devices by USB topology (bus, port chain) for deterministic boardId mapping across reboots
- Fix use-after-free: call libusb_open() before libusb_free_device_list()