### PR TITLE
Release candidate for 0.7.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to LEDSpicer will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.4] - 2026-05-03
+
+### Added
+- `restartTime` parameter for actors: delay before restarting after `endTime` expires
+- Time is now frame-based, syncing multiple actors to the same point in time
+
+### Changed
+- Time and duration values now accept decimals (e.g. `1.5` seconds)
+- Repeat limit increased from 255 to 65535
+- Improved actor runtime validation
+- `checkRepeats()` infinite repeat behavior corrected
+
+### Removed
+- `cycles` parameter from FrameActor, replaced by `endTime`
+
+### Fixed
+- Serpentine animation debug log showed wrong position
+- Element reset loop applied incorrectly in some cases
+
 ## [0.7.3] - 2026-01-28
 
 ### Added

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 
-project(LEDSpicer VERSION 0.7.3 LANGUAGES CXX)
+project(LEDSpicer VERSION 0.7.4 LANGUAGES CXX)
 
 
 include(GNUInstallDirs)

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,27 +1,17 @@
-ledspicer (0.7.3-1ubuntu3) UNRELEASED; urgency=medium
+ledspicer (0.7.4-1) stable; urgency=medium
 
-  * Fixed Debian errors
+  * Added
+    - `restartTime` parameter for actors: delay before restarting after `endTime` expires
+    - Time is now frame-based, syncing multiple actors to the same point in time
+  * Changed
+    - Time and duration values now accept decimals (e.g. `1.5` seconds)
+    - Repeat limit increased from 255 to 65535
+    - Improved actor runtime validation
+    - `checkRepeats()` infinite repeat behavior corrected
+  * Removed
+    - `cycles` parameter from FrameActor, replaced by `endTime`
+  * Fixed
+    - Serpentine animation debug log showed wrong position
+    - Element reset loop applied incorrectly in some cases
 
- -- Patricio Rossi <meduza@Desktop01>  Thu, 29 Jan 2026 12:47:46 -0500
-
-ledspicer (0.7.3-1ubuntu1) UNRELEASED; urgency=medium
-
-  * Fixed Debian errors
-
- -- Patricio Rossi <meduza@Desktop01>  Wed, 28 Jan 2026 21:51:56 -0500
-
-ledspicer (0.7.3-1) Resolute Noble Jammy; urgency=medium
-
-  * Added:
-    - Support for separate project directories (`-j/--project` and `-J/--projects-dir` CLI options).
-    - LayoutProperties struct for layout handling.
-    - Unit tests for core utilities and device handling.
-  * Fixed:
-    - Servostiks board works in multi-board setups.
-    - Pulseaudio actor now reconnects automatically and avoids fatal failures.
-  * Changed:
-    - Centralized path handling ensures consistent trailing slashes.
-    - Systemd service files improved: graceful shutdown, optional Pulseaudio support for daemons.
-    - Utility::getHomeDir() now resolves the correct home directory after privilege drops.
-
- -- Patricio A. Rossi <meduzapat@netscape.net>  Wed, 28 Jan 2026 16:46:20 -0500
+ -- Patricio A. Rossi <meduzapat@netscape.net>  Sun, 03 May 2026 12:23:10 -0400

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -15,12 +15,13 @@ pkgname=(
 	'ledspicer-dev'
 )
 
-pkgver=0.7.3
-pkgrel=3
+pkgver=0.7.4
+pkgrel=1
 pkgdesc="LED controller daemon for arcade cabinets and RGB lighting"
 arch=('x86_64' 'aarch64' 'armv7h')
 url="https://github.com/meduzapat/LEDSpicer"
 license=('GPL3')
+options=(docs)
 
 makedepends=(
 	'cmake>=3.10'
@@ -33,7 +34,7 @@ makedepends=(
 )
 
 source=("${pkgbase}-${pkgver}.tar.gz::https://github.com/meduzapat/LEDSpicer/archive/refs/tags/${pkgver}.tar.gz")
-sha256sums=('770f958e3ad3d6805878dddbd3c22478a3489d3847c378e9af62feed4cd6916d')
+sha256sums=('d5558cd419c8d46bdc958064cb97f963d1ea793866414c025906ec15033512ed')
 
 build() {
 	cd "${srcdir}/LEDSpicer-${pkgver}"
@@ -52,6 +53,8 @@ build() {
 		-DENABLE_LEDWIZ32=ON
 		-DENABLE_HOWLER=ON
 		-DENABLE_ADALIGHT=ON
+		-DCMAKE_SKIP_BUILD_RPATH=ON
+		-DCMAKE_INSTALL_RPATH=""
 	)
 
 	cmake -S . -B build "${cmake_opts[@]}"
@@ -74,6 +77,7 @@ package_libledspicer() {
 	rm -rf "${pkgdir}/usr/lib/ledspicer"
 	rm -rf "${pkgdir}/usr/share"
 	rm -rf "${pkgdir}/usr/lib/systemd"
+	rm -rf "${pkgdir}/usr/share/doc"
 
 	find "${pkgdir}/usr/lib" -type f ! -name 'libledspicer.so.*' -delete
 }
@@ -103,6 +107,11 @@ package_ledspicer() {
 
 	DESTDIR="${pkgdir}" cmake --install "${srcdir}/LEDSpicer-${pkgver}/build"
 
+	# Move examples to /usr/share/ledspicer/examples for robustness (avoids any doc stripping)
+	install -dm755 "${pkgdir}/usr/share/ledspicer/examples"
+	mv "${pkgdir}/usr/share/doc/ledspicer/examples/"* "${pkgdir}/usr/share/ledspicer/examples/" 2>/dev/null || true
+	rm -rf "${pkgdir}/usr/share/doc/ledspicer/examples"
+
 	# Remove library artifacts (handled by libledspicer)
 	rm -f "${pkgdir}/usr/lib/libledspicer.so"*
 	rm -rf "${pkgdir}/usr/include"
@@ -111,6 +120,9 @@ package_ledspicer() {
 	# Remove plugins (handled by subpackages)
 	rm -rf "${pkgdir}/usr/lib/ledspicer/devices"
 	install -dm755 "${pkgdir}/usr/lib/ledspicer/devices"
+
+	# Install license per Arch guidelines
+	install -Dm644 "${srcdir}/LEDSpicer-${pkgver}/COPYING" "${pkgdir}/usr/share/licenses/${pkgname}/COPYING"
 }
 
 # =============================================================================

--- a/packaging/arch/generate SRCINFO.sh
+++ b/packaging/arch/generate SRCINFO.sh
@@ -5,20 +5,24 @@ docker run --rm \
 	-v "$PWD:/pkg" \
 	-w /pkg \
 	archlinux:latest \
-	bash -c "
+	bash -c '
 		set -e
 
 		pacman -Sy --noconfirm archlinux-keyring
-		pacman -S --noconfirm base-devel git sudo
+		pacman -S --noconfirm --needed base-devel git sudo
 
 		useradd -m builder
-		echo 'builder ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers
+		echo "builder ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 		chown -R builder:builder /pkg
 
-		su - builder -c '
+		su - builder -c "
 			cd /pkg
-			makepkg --printsrcinfo > .SRCINFO
-		cat .SRCINFO
-		'
-	"
 
+			echo \"==> CHECKSUMS (print-only)\"
+			makepkg -g --print
+
+			echo
+			echo \"==> .SRCINFO (print-only)\"
+			makepkg --printsrcinfo
+		"
+	'

--- a/packaging/rpm/ledspicer.spec
+++ b/packaging/rpm/ledspicer.spec
@@ -5,8 +5,8 @@
 %global debug_package %{nil}
 
 Name:           ledspicer
-Version:        0.7.3
-Release:        3%{?dist}
+Version:        0.7.4
+Release:        1%{?dist}
 Summary:        LED controller daemon for arcade cabinets and RGB lighting
 License:        GPL-3.0-or-later
 URL:            https://github.com/meduzapat/LEDSpicer
@@ -196,15 +196,17 @@ that use the LEDSpicer library.
 # =============================================================================
 
 %changelog
-* Thu Jan 29 2026 Patricio A. Rossi <meduzapat@netscape.net> - 0.7.3-1
+* Sun May 03 2026 Patricio A. Rossi <meduzapat@netscape.net> - 0.7.4-1
 - Added
-  - Support for separate project directories (`-j/--project` and `-J/--projects-dir` CLI options).
-  - `LayoutProperties` struct for layout handling.
-  - Unit tests for core utilities and device handling.
-- Fixed
-  - Servostiks board works in multi-board setups.
-  - Pulseaudio actor now reconnects automatically and avoids fatal failures.
+  - `restartTime` parameter for actors: delay before restarting after `endTime` expires
+  - Time is now frame-based, syncing multiple actors to the same point in time
 - Changed
-  - Centralized path handling ensures consistent trailing slashes.
-  - Systemd service files improved: graceful shutdown, optional Pulseaudio support for daemons.
-  - `Utility::getHomeDir()` now resolves the correct home directory after privilege drops.
+  - Time and duration values now accept decimals (e.g. `1.5` seconds)
+  - Repeat limit increased from 255 to 65535
+  - Improved actor runtime validation
+  - `checkRepeats()` infinite repeat behavior corrected
+- Removed
+  - `cycles` parameter from FrameActor, replaced by `endTime`
+- Fixed
+  - Serpentine animation debug log showed wrong position
+  - Element reset loop applied incorrectly in some cases

--- a/src/animations/Actor.cpp
+++ b/src/animations/Actor.cpp
@@ -33,14 +33,17 @@ Actor::Actor(
 	const vector<string>& requiredParameters
 ) :
 	filter(Color::str2filter(parameters.exists("filter") ? parameters["filter"] : "Normal")),
-	secondsToStart(parameters.exists("startTime") ? Utility::parseNumber(parameters["startTime"], "Invalid Value for start time") : 0),
-	secondsToEnd(parameters.exists("endTime") ? Utility::parseNumber(parameters["endTime"], "Invalid Value for end time") : 0),
+	secondsToStart(parameters.exists("startTime")     ? Utility::parseNumber(parameters["startTime"],   "Invalid Value for start time")   : 0),
+	secondsToEnd(parameters.exists("endTime")         ? Utility::parseNumber(parameters["endTime"],     "Invalid Value for end time")     : 0),
+	secondsToRestart(parameters.exists("restartTime") ? Utility::parseNumber(parameters["restartTime"], "Invalid Value for restart time") : 0),
 	affectedElements(group->size(), false),
 	group(group),
 	repeat(parameters.exists("repeat") ? Utility::parseNumber(parameters["repeat"], "Invalid Value for repeat") : 0)
 {
 	affectedElements.shrink_to_fit();
 	Utility::checkAttributes(requiredParameters, parameters, "actor");
+	if (secondsToRestart and not secondsToEnd)
+		LogWarning("restartTime has no effect without endTime");
 }
 
 Group& Actor::getGroup() const {
@@ -49,7 +52,8 @@ Group& Actor::getGroup() const {
 
 void Actor::draw() {
 
-	if (not isRunning()) return;
+	wasRunning = isRunning();
+	if (not wasRunning) return;
 
 	// Reset Affected.
 	affectAllElements();
@@ -65,19 +69,23 @@ void Actor::draw() {
 }
 
 void Actor::drawConfig() const {
+
 	cout <<
-		"Group: " << group->getName() << endl <<
+		"Group: "  << group->getName()          << endl <<
 		"Filter: " << Color::filter2str(filter) << endl;
+
 	if (secondsToStart)
-		cout << "Start After: "     << secondsToStart << " sec"   << endl;
+		cout << "Start After: "   << secondsToStart   << " sec"   << endl;
 	if (secondsToEnd)
-		cout << "Stop After: "      << secondsToEnd   << " sec"   << endl;
+		cout << "Stop After: "    << secondsToEnd     << " sec"   << endl;
+	if (secondsToRestart)
+		cout << "Restart After: " << secondsToRestart << " sec"   << endl;
 	if (repeat)
-		cout << "Will repeat for: " << repeat         << " times" << endl;
-	if (acceptCycles()) {
-		cout << "Frames: " << getFullFrames() << " (" << getFullFrames() / FPS << " sec)" << endl;
-	}
-	cout << "Total running time: " << (getRunTime() ? to_string(getRunTime()) : "∞") << " sec" << endl
+		cout << "Will repeat: "   << repeat           << " times" << endl;
+
+	auto rt {getRunTime()};
+	cout << "Total running time: " << (rt > 0.0f ? to_string(rt) : "∞")
+		 << " sec"    << endl
 		 << SEPARATOR << endl;
 }
 
@@ -90,6 +98,11 @@ void Actor::restart() {
 		endTime = nullptr;
 	}
 
+	if (restartTime) {
+		delete restartTime;
+		restartTime = nullptr;
+	}
+
 	if (secondsToStart) {
 		if (startTime) delete startTime;
 		startTime = new Time(secondsToStart);
@@ -100,26 +113,50 @@ void Actor::restart() {
 }
 
 bool Actor::isRunning() {
+
 	if (startTime) {
+		// Start time is running (actor off).
 		if (not startTime->isTime()) return false;
+		// Start time is over (actor on)
 		delete startTime;
 		startTime = nullptr;
 #ifdef DEVELOP
 		LogDebug("Starting Actor by time after " + to_string(secondsToStart) + " seconds");
 #endif
+		// Set end clock.
 		if (secondsToEnd) endTime = new Time(secondsToEnd);
 	}
 
 	if (endTime and endTime->isTime()) {
+		// End time (actor off).
 		delete endTime;
 		endTime = nullptr;
 #ifdef DEVELOP
 		LogDebug("Ended Actor by time after " + to_string(secondsToEnd) + " seconds");
 #endif
+		// Set restart clock if any.
+		if (secondsToRestart) {
+			restartTime = new Time(secondsToRestart);
+		}
+		return false;
+	}
+
+	if (restartTime) {
+		// Restart clock running.
+		if (not restartTime->isTime()) return false;
+		// Restart time reached, check repeats.
+		delete restartTime;
+		restartTime = nullptr;
+	#ifdef DEVELOP
+		LogDebug("Restarting Actor after " + to_string(secondsToRestart) + " seconds");
+	#endif
+		checkRepeats();
+		return false;
 	}
 
 	if (not endTime and secondsToEnd) {
-		return checkRepeats();
+		checkRepeats();
+		return endTime;
 	}
 	return true;
 }
@@ -134,7 +171,10 @@ uint8_t Actor::getFPS() {
 }
 
 void Actor::newFrame() {
-	if (frame == FPS) frame = 0;
+	if (frame == FPS) {
+		frame = 0;
+		Time::setFrameTime();
+	}
 	++frame;
 }
 
@@ -166,8 +206,8 @@ bool Actor::isElementAffected(uint16_t index) const {
 }
 
 bool Actor::checkRepeats() {
-	if (not repeat or repeat == 1 or repeated == repeat) return false;
-	++repeated;
+	if (repeat == 1 or (repeat and repeated == repeat)) return false;
+	if (repeat) ++repeated;
 	restart();
 	return true;
 }

--- a/src/animations/Actor.hpp
+++ b/src/animations/Actor.hpp
@@ -99,21 +99,6 @@ public:
 	static uint8_t getFPS();
 
 	/**
-	 *
-	 * @return true If the actor can be handled by time.
-	 */
-	virtual bool acceptTime() {
-		return true;
-	}
-
-	/**
-	 * @return true If the actor can be handled by cycles.
-	 */
-	virtual bool acceptCycles() const {
-		return false;
-	}
-
-	/**
 	 * Increments the frame counter, resetting at FPS limit.
 	 */
 	static void newFrame();
@@ -169,17 +154,24 @@ protected:
 	/// Color filter applied to elements.
 	Color::Filters filter = Color::Filters::Normal;
 
-	uint16_t
+	float
 		/// Number of seconds to wait until start processing this actor.
-		secondsToStart = 0,
+		secondsToStart   = 0,
 		/// Number of seconds to wait to stop this actor.
-		secondsToEnd   = 0;
+		secondsToEnd     = 0,
+		/// Number of seconds to wait after endTime before restarting.
+		secondsToRestart = 0;
 
 	Time
 		/// Start time clock for this actor.
-		* startTime = nullptr,
+		* startTime   = nullptr,
 		/// End time clock for this actor.
-		* endTime = nullptr;
+		* endTime     = nullptr,
+		/// Restart delay clock, armed after endTime expires.
+		* restartTime = nullptr;
+
+	/// Set by draw(), true if the actor was running during the last draw call.
+	bool wasRunning = false;
 
 	/**
 	 * Do the elements calculation.
@@ -218,9 +210,9 @@ private:
 	Group* const group;
 
 	/// If this actor will repeat, default 0 to repeat for ever.
-	const uint8_t repeat;
+	const uint16_t repeat;
 	/// Times repeated.
-	uint8_t	repeated = 1;
+	uint16_t repeated = 1;
 };
 
 using ActorPtrsUmap = unordered_map<string, vector<Actor*>>;

--- a/src/animations/FrameActor.cpp
+++ b/src/animations/FrameActor.cpp
@@ -31,16 +31,13 @@ FrameActor::FrameActor(
 ) :
 	Actor(parameters, group, requiredParameters),
 	Speed(parameters["speed"]),
-	startAt(parameters.exists("startAt") ? Utility::parseNumber(parameters["startAt"], "Invalid Value for start at") : 0),
-	cycles(parameters.exists("cycles")   ? Utility::parseNumber(parameters["cycles"],  "Invalid Value for cycles")   : 0)
+	startAt(parameters.exists("startAt") ? Utility::parseNumber(parameters["startAt"], "Invalid Value for start at") : 0)
 {
 	Utility::verifyValue<uint8_t>(startAt, 0, 100);
 }
 
 void FrameActor::drawConfig() const {
 	Speed::drawConfig();
-	if (cycles)
-		cout << "Will run for: " << to_string(cycles) << " Cycles" << endl;
 	if (startAt)
 		cout << "Start at Frame: " << to_string(startAt) << endl;
 	Actor::drawConfig();
@@ -64,7 +61,7 @@ bool FrameActor::isEndOfCycle() const {
 
 void FrameActor::draw() {
 	Actor::draw();
-	advanceFrame();
+	if (wasRunning) advanceFrame();
 }
 
 void FrameActor::restart() {
@@ -78,30 +75,7 @@ void FrameActor::restart() {
 	else {
 		stepping.frame = 0;
 	}
-	cycle         = 0;
 	stepping.step = 0;
-}
-
-bool FrameActor::isRunning() {
-
-	if (not Actor::isRunning()) return false;
-
-	if (cycles) {
-		// Avoids repeating log messages.
-		if (cycle > cycles) return checkRepeats();
-
-		if (cycle == cycles) {
-#ifdef DEVELOP
-			LogDebug("Actor completed after " + to_string(cycles) + " cycles");
-#endif
-			// Increase it by one so the debug message does not repeat.
-			++cycle;
-			return checkRepeats();
-		}
-		if (isEndOfCycle()) ++cycle;
-	}
-
-	return true;
 }
 
 uint16_t FrameActor::getFullFrames() const {
@@ -109,9 +83,8 @@ uint16_t FrameActor::getFullFrames() const {
 }
 
 float FrameActor::getRunTime() const {
-	float baseTime    = cycles ? (static_cast<float>(getFullFrames() * cycles) / FPS) : secondsToEnd;
 	float startAtTime = (startAt * getFullFrames()) / (100.0f * FPS);
-	return baseTime + secondsToStart + startAtTime;
+	return secondsToEnd + secondsToStart + startAtTime;
 }
 
 uint16_t FrameActor::calculateStepsBySpeed(Speeds speed) {
@@ -139,5 +112,3 @@ uint16_t FrameActor::calculateFramesBySpeed(Speeds speed) {
 void FrameActor::advanceFrame() {
 	stepping.advanceStep();
 }
-
-

--- a/src/animations/FrameActor.hpp
+++ b/src/animations/FrameActor.hpp
@@ -127,12 +127,6 @@ public:
 	 */
 	void restart() override;
 
-	bool isRunning() override;
-
-	bool acceptCycles() const override {
-		return true;
-	}
-
 	uint16_t getFullFrames() const override;
 
 	float getRunTime() const override;
@@ -155,13 +149,8 @@ protected:
 
 	Stepping stepping;
 
-	uint8_t
-		/// The percent of the animation to start.
-		startAt = 0,
-		/// Will run for this number of cycles.
-		cycles  = 0,
-		/// Current cycle.
-		cycle   = 0;
+	/// The percent of the animation to start.
+	uint8_t startAt = 0;
 
 	/**
 	 * Advances the system frame forward.
@@ -171,4 +160,3 @@ protected:
 };
 
 } // namespace
-

--- a/src/animations/Serpentine.cpp
+++ b/src/animations/Serpentine.cpp
@@ -94,7 +94,7 @@ void Serpentine::calculateElements() {
 		if (tailData[i].position == stepping.frame) {
 #ifdef DEVELOP
 			if (Log::isLogging(LOG_DEBUG)) {
-				cout << std::setw(2) << static_cast<uint16_t>(data.position + 1) << "=--% ";
+				cout << std::setw(2) << static_cast<uint16_t>(tailData[i].position + 1) << "=--% ";
 			}
 #endif
 			continue;

--- a/src/devices/Profile.cpp
+++ b/src/devices/Profile.cpp
@@ -85,11 +85,12 @@ void Profile::runFrame(bool advanceFrame) {
 	if (advanceFrame) Actor::newFrame();
 
 	// Reset elements.
-	for (const auto& e : Element::allElements)
+	for (const auto& e : Element::allElements) {
 		if (e.second->isTimed())
 			e.second->checkTime();
 		else
 			e.second->setColor(backgroundColor);
+	}
 
 	if (not transitioning and inputsEnabled) {
 		for (Input* i : inputs) i->process();

--- a/src/utilities/Time.cpp
+++ b/src/utilities/Time.cpp
@@ -24,14 +24,20 @@
 
 using namespace LEDSpicer::Utilities;
 
-Time::Time(uint16_t seconds) {
-	timeOnExpiration = std::chrono::system_clock::now() + std::chrono::seconds(seconds);
+Time::Time(float seconds) {
+	timeOnExpiration = frameTime + std::chrono::duration_cast<std::chrono::nanoseconds>(
+		std::chrono::duration<float>(seconds)
+	);
 }
 
-void Time::reset(uint16_t milliseconds) {
+void Time::reset(uint milliseconds) {
 	timeOnExpiration = std::chrono::system_clock::now() + std::chrono::milliseconds(milliseconds);
 }
 
 bool Time::isTime() const {
 	return (std::chrono::system_clock::now() > timeOnExpiration);
+}
+
+void Time::setFrameTime() {
+	frameTime = system_clock::now();
 }

--- a/src/utilities/Time.hpp
+++ b/src/utilities/Time.hpp
@@ -44,7 +44,7 @@ public:
 	 * Creates an object using seconds
 	 * @param seconds
 	 */
-	Time(uint16_t seconds);
+	Time(float seconds);
 
 	virtual ~Time() = default;
 
@@ -57,9 +57,17 @@ public:
 	 * Resets the clock to milliseconds.
 	 * @param milliseconds
 	 */
-	void reset(uint16_t milliseconds);
+	void reset(uint milliseconds);
+
+	/**
+	 * Sets the point where a frame started.
+	 */
+	static void setFrameTime();
 
 protected:
+
+	/// Shared frame anchor — all timers use this as their "now".
+	inline static system_clock::time_point frameTime = system_clock::now();
 
 	/// Calculated timepoint to finish.
 	system_clock::time_point timeOnExpiration = {};

--- a/tests/packaging/test-aur.sh
+++ b/tests/packaging/test-aur.sh
@@ -12,34 +12,34 @@ ARCHITECTURES=("x86_64")
 
 test_arch_linux() {
 	local arch=$1 container_name="ledspicer-aur-test-${arch}"
-	
+
 	print_step "Testing Arch Linux (${arch})"
-	
+
 	docker run --rm -it --platform linux/${arch} --name ${container_name} archlinux:latest bash -c "
 		set -e
 		pacman -Syu --noconfirm
 		pacman -S --noconfirm base-devel git sudo
-		
+
 		useradd -m builder
 		echo 'builder ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers
-		
+
 		su - builder -c 'git clone https://aur.archlinux.org/yay.git && cd yay && makepkg -si --noconfirm'
 		su - builder -c 'yay -S --noconfirm ${AUR_PACKAGE}'
-		
+
 		command -v ledspicerd >/dev/null && command -v processLookup >/dev/null && command -v inputseeker >/dev/null && ledspicerd --version
-		
+
 		plugin_count=\$(find /usr/lib/ledspicer/devices/ -name '*.so' 2>/dev/null | wc -l)
 		[ \$plugin_count -eq 0 ] || { echo 'ERROR: Base package contains plugins'; exit 1; }
-		
+
 		ls /usr/share/doc/ledspicer/examples/ >/dev/null 2>&1 || { echo 'ERROR: Examples directory missing'; exit 1; }
-		
+
 		PLUGINS=('ledspicer-nanoled' 'ledspicer-pacdrive' 'ledspicer-pacled64' 'ledspicer-ultimateio' 'ledspicer-ledwiz32' 'ledspicer-howler' 'ledspicer-adalight')
 		for plugin in \${PLUGINS[@]}; do su - builder -c \"yay -S --noconfirm \$plugin\" || { echo \"ERROR: Failed to install \$plugin\"; exit 1; }; done
-		
+
 		plugin_count=\$(find /usr/lib/ledspicer/devices/ -name '*.so' 2>/dev/null | wc -l)
 		[ \$plugin_count -eq 7 ] || { echo \"ERROR: Expected 7 plugins, found \$plugin_count\"; ls -la /usr/lib/ledspicer/devices/; exit 1; }
 	"
-	
+
 	if [ $? -eq 0 ]; then
 		print_step "✓ Arch Linux (${arch}) PASSED"
 		return 0
@@ -52,7 +52,7 @@ test_arch_linux() {
 main() {
 	print_step "Starting tests (Arch Linux latest)"
 	local failed=0 total=0 failed_tests=""
-	
+
 	for arch in "${ARCHITECTURES[@]}"; do
 		total=$((total + 1))
 		if ! test_arch_linux "$arch"; then
@@ -61,7 +61,7 @@ main() {
 		fi
 		echo ""
 	done
-	
+
 	echo "======================================"
 	echo "Results: Total $total, Passed $((total - failed)), Failed $failed"
 	[ -z "$failed_tests" ] || echo -e "Failed:\n$failed_tests"

--- a/tests/src/animations/ActorTest.cpp
+++ b/tests/src/animations/ActorTest.cpp
@@ -37,7 +37,9 @@ namespace LEDSpicer::Animations {
  * Minimal derived class for testing Actor.
  */
 class TestActor : public Actor {
+
 public:
+
 	TestActor(
 		StringUMap&           parameters,
 		Group* const          group,
@@ -53,6 +55,7 @@ public:
 	}
 
 protected:
+
 	void calculateElements() override {
 		affectAllElements(true);
 	}
@@ -85,13 +88,18 @@ TEST(ActorTest, Constructor) {
 	EXPECT_EQ(actor.getGroup().getName(), "TestGroup");
 	EXPECT_EQ(actor.getNumberOfElements(), 0);
 	// Activate actor
+	Time::setFrameTime();
 	actor.restart();
-	// False due to to seconds start.
 	EXPECT_FALSE(actor.isRunning());
+
 	sleep_for(std::chrono::milliseconds(1001));
+	Time::setFrameTime();
 	EXPECT_TRUE(actor.isRunning());
+
 	sleep_for(std::chrono::milliseconds(1001));
+	Time::setFrameTime();
 	EXPECT_FALSE(actor.isRunning());
+
 	// Test LEDs.
 	EXPECT_EQ(actor.getLeds().size(), 0);
 }
@@ -210,16 +218,35 @@ TEST(ActorTest, RepeatFunctionality) {
 	};
 	const vector<string> required = {"type", "group", "filter"};
 	TestActor actor(params, &group, required);
+
+	Time::setFrameTime();
 	actor.restart();
 	// Wait for startTime (0s, immediate start)
 	EXPECT_TRUE(actor.isRunning());
-	// Wait for endTime (1s)
-	sleep_for(std::chrono::milliseconds(1001));
-	// First repeat should trigger restart
+
+	// First loop.
+	sleep_for(std::chrono::milliseconds(900));
+	Time::setFrameTime();
 	EXPECT_TRUE(actor.isRunning());
+
+	// Wait for endTime (0.1s) not running
+	sleep_for(std::chrono::milliseconds(100));
+	Time::setFrameTime();
+	EXPECT_FALSE(actor.isRunning());
+
+	// First repeat should trigger restart.
+	sleep_for(std::chrono::milliseconds(900));
+	Time::setFrameTime();
+	EXPECT_TRUE(actor.isRunning());
+
 	// Wait for endTime again (1s)
 	sleep_for(std::chrono::milliseconds(1001));
+	Time::setFrameTime();
+	EXPECT_FALSE(actor.isRunning());
+
 	// No more repeats, should stop
+	sleep_for(std::chrono::milliseconds(1001));
+	Time::setFrameTime();
 	EXPECT_FALSE(actor.isRunning());
 }
 
@@ -260,11 +287,11 @@ TEST(ActorTest, DrawConfig) {
 	Log::setLogLevel(LOG_ERR);
 	actor.drawConfig();
 	string output = testing::internal::GetCapturedStdout();
-	EXPECT_NE(output.find("Group: TestGroup"),         string::npos);
-	EXPECT_NE(output.find("Filter: Combine"),          string::npos);
-	EXPECT_NE(output.find("Start After: 2 sec"),       string::npos);
-	EXPECT_NE(output.find("Stop After: 10 sec"),       string::npos);
-	EXPECT_EQ(output.find("Will repeat for: 3 times"), string::npos);
+	EXPECT_NE(output.find("Group: TestGroup"),     string::npos);
+	EXPECT_NE(output.find("Filter: Combine"),      string::npos);
+	EXPECT_NE(output.find("Start After: 2 sec"),   string::npos);
+	EXPECT_NE(output.find("Stop After: 10 sec"),   string::npos);
+	EXPECT_NE(output.find("Will repeat: 3 times"), string::npos);
 }
 
 TEST(ActorTest, AffectAllElementsWithMask) {
@@ -320,6 +347,50 @@ TEST(ActorTest, AffectAllElementsWithMask) {
 	actor2.draw();
 	EXPECT_EQ(ledValue1, 124);
 	EXPECT_EQ(ledValue2, 0);
+}
+
+TEST(ActorTest, RestartTimeInfinite) {
+	Group group(
+		"TestGroup",
+		DEFAULT_COLOR
+	);
+	StringUMap params = {
+		{"type",        "Test"},
+		{"group",       "TestGroup"},
+		{"filter",      "Normal"},
+		{"endTime",     "1"},
+		{"restartTime", "1"}
+	};
+
+	const vector<string> required = {"type", "group", "filter"};
+	TestActor actor(params, &group, required);
+	Time::setFrameTime();
+	actor.restart();
+
+	// Cycle 1: running.
+	EXPECT_TRUE(actor.isRunning());
+	sleep_for(std::chrono::milliseconds(1001));
+	Time::setFrameTime();
+
+	// endTime fired → paused.
+	EXPECT_FALSE(actor.isRunning());
+	sleep_for(std::chrono::milliseconds(1001));
+	Time::setFrameTime();
+
+	// restartTime fired → cycle 2 running.
+	EXPECT_FALSE(actor.isRunning()); // this kicks restart
+	EXPECT_TRUE(actor.isRunning());
+	sleep_for(std::chrono::milliseconds(1001));
+	Time::setFrameTime();
+
+	// endTime fired → paused again.
+	EXPECT_FALSE(actor.isRunning());
+	sleep_for(std::chrono::milliseconds(1001));
+	Time::setFrameTime();
+
+	// restartTime fired → cycle 3 still running (infinite).
+	EXPECT_FALSE(actor.isRunning()); // this kicks restart
+	EXPECT_TRUE(actor.isRunning());
 }
 
 int main(int argc, char **argv) {

--- a/tests/src/animations/FrameActorTest.cpp
+++ b/tests/src/animations/FrameActorTest.cpp
@@ -37,35 +37,25 @@ namespace LEDSpicer::Animations {
  * Minimal derived class for testing FrameActor.
  */
 class TestFrameActor : public FrameActor {
+
 public:
+
 	TestFrameActor(
 		StringUMap&           parameters,
 		Group* const          group,
 		const vector<string>& requiredParameters
 	) : FrameActor(parameters, group, requiredParameters) {}
 
-	/**
-	 * @param stepping the stepping to test.
-	 */
 	void setStepping(FrameActor::Stepping stepping) {
 		this->stepping = stepping;
 	}
 
-	/**
-	 * @return the stepping.
-	 */
 	FrameActor::Stepping  getStepping() {
 		return stepping;
 	}
 
-	/**
-	 * @return the current cycle.
-	 */
-	uint8_t getCycle() {
-		return cycle;
-	}
-
 protected:
+
 	void calculateElements() override {
 		affectAllElements(true);
 	}
@@ -81,14 +71,12 @@ TEST(FrameActorTest, Constructor) {
 		{"group",   "TestGroup"},
 		{"filter",  "Normal"},
 		{"speed",   "Normal"},
-		{"startAt", "10"},
-		{"cycles",  "2"}
+		{"startAt", "10"}
 	};
 	const vector<string> required = {"type", "group", "filter"};
 	TestFrameActor actor(params, &group, required);
 	EXPECT_EQ(actor.getStepping().frames, 0);
 	EXPECT_EQ(actor.getStepping().frame, 0);
-	EXPECT_EQ(actor.getCycle(), 0);
 }
 
 TEST(FrameActorTest, SpeedVariations) {
@@ -124,83 +112,6 @@ TEST(FrameActorTest, StartAt) {
 	actor.setStepping(stepping);
 	actor.restart();
 	EXPECT_EQ(actor.getStepping().frame, 29); // (60 * (50-1)) / 100 = 29.4 -> 29
-}
-
-TEST(FrameActorTest, Cycles) {
-	Group group("TestGroup", DEFAULT_COLOR);
-	StringUMap params = {
-		{"type",   "Test"},
-		{"group",  "TestGroup"},
-		{"filter", "Normal"},
-		{"speed",  "VeryFast"},
-		{"cycles", "2"}
-	};
-	const vector<string> required = {"type", "group", "filter"};
-	TestFrameActor actor(params, &group, required);
-	// 20 Frames.
-	FrameActor::Stepping stepping;
-	stepping.frames = FrameActor::calculateFramesBySpeed(Speed::Speeds::VeryFast);
-	actor.setStepping(stepping);
-	actor.restart();
-	EXPECT_TRUE(actor.isRunning());
-	EXPECT_EQ(actor.getCycle(), 0);
-
-	// Simulate one cycle + 1 (20 frames from 0 to 0)
-	for (int i = 0; i < 20; ++i) actor.draw();
-	EXPECT_EQ(actor.getStepping().frame, 0);
-	EXPECT_TRUE(actor.isRunning());
-	EXPECT_EQ(actor.getCycle(), 1);
-
-	// Simulate second cycle
-	for (int i = 0; i < 20; ++i) actor.draw();
-	EXPECT_EQ(actor.getStepping().frame, 0);
-	EXPECT_EQ(actor.getCycle(), 2);
-	EXPECT_FALSE(actor.isRunning());
-	// this will be 3 instead of 2 due to the log protector.
-	EXPECT_EQ(actor.getCycle(), 3);
-}
-
-// New test case for Cycles and Repeats
-TEST(FrameActorTest, CyclesAndRepeats) {
-	Group group("TestGroup", DEFAULT_COLOR);
-	StringUMap params = {
-		{"type",   "Test"},
-		{"group",  "TestGroup"},
-		{"filter", "Normal"},
-		{"speed",  "VeryFast"},
-		{"cycles", "2"},
-		{"repeat", "2"}
-	};
-	const vector<string> required = {"type", "group", "filter"};
-	TestFrameActor actor(params, &group, required);
-	FrameActor::Stepping stepping;
-	stepping.frames = FrameActor::calculateFramesBySpeed(Speed::Speeds::VeryFast);
-	actor.setStepping(stepping);
-	actor.restart();
-	// Simulate one cycle + 1 (20 frames from 0 to 0)
-	for (int i = 0; i < 20; ++i) actor.draw();
-	EXPECT_EQ(actor.getStepping().frame, 0);
-	EXPECT_TRUE(actor.isRunning());
-	EXPECT_EQ(actor.getCycle(), 1);
-
-	// Simulate second cycle
-	for (int i = 0; i < 20; ++i) actor.draw();
-	EXPECT_EQ(actor.getStepping().frame, 0);
-	EXPECT_EQ(actor.getCycle(), 2);
-	EXPECT_TRUE(actor.isRunning());
-
-	// Simulate first cycle of second repeat
-	for (int i = 0; i < 20; ++i) actor.draw();
-	EXPECT_EQ(actor.getStepping().frame, 0);
-	EXPECT_EQ(actor.getCycle(), 1);
-	EXPECT_TRUE(actor.isRunning());
-
-	// Simulate second cycle of second repeat
-	for (int i = 0; i < 20; ++i) actor.draw();
-	EXPECT_EQ(actor.getStepping().frame, 0);
-	EXPECT_EQ(actor.getCycle(), 2);
-	// At this point it ran 4 times 2x2.
-	EXPECT_FALSE(actor.isRunning());
 }
 
 TEST(FrameActorTest, FrameAdvance) {
@@ -282,7 +193,6 @@ TEST(FrameActorTest, RunTime) {
 		{"filter",    "Normal"},
 		{"speed",     "Normal"},
 		{"startAt",   "50"},
-		{"cycles",    "2"},
 		{"startTime", "1"},
 		{"endTime",   "2"}
 	};
@@ -292,8 +202,8 @@ TEST(FrameActorTest, RunTime) {
 	stepping.frames = FrameActor::calculateFramesBySpeed(Speed::Speeds::Normal);
 	actor.setStepping(stepping);
 	actor.restart();
-	// Run time = (cycles * frames / FPS) + startTime + (startAt * frames / (100 * FPS))
-	// = (2 * 60 / 60) + 1 + (50 * 60 / (100 * 60)) = 2 + 1 + 0.5 = 3.5
+	// Run time = startTime + endTime + (startAt * frames) / (100 * FPS)
+	// = 1 + 2 + (50 * 60) / (100 * 60) = 3 + 0.5 = 3.5
 	EXPECT_FLOAT_EQ(actor.getRunTime(), 3.5f);
 }
 
@@ -304,8 +214,7 @@ TEST(FrameActorTest, DrawConfig) {
 		{"group",   "TestGroup"},
 		{"filter",  "Normal"},
 		{"speed",   "Fast"},
-		{"startAt", "10"},
-		{"cycles",  "3"}
+		{"startAt", "10"}
 	};
 	const vector<string> required = {"type", "group", "filter"};
 	TestFrameActor actor(params, &group, required);
@@ -316,9 +225,8 @@ TEST(FrameActorTest, DrawConfig) {
 	Log::setLogLevel(LOG_ERR);
 	actor.drawConfig();
 	string output = testing::internal::GetCapturedStdout();
-	EXPECT_NE(output.find("Speed: Fast"),            string::npos);
-	EXPECT_NE(output.find("Will run for: 3 Cycles"), string::npos);
-	EXPECT_NE(output.find("Start at Frame: 10"),     string::npos);
+	EXPECT_NE(output.find("Speed: Fast"),        string::npos);
+	EXPECT_NE(output.find("Start at Frame: 10"), string::npos);
 }
 
 int main(int argc, char **argv) {

--- a/tests/src/utilities/TimeTest.cpp
+++ b/tests/src/utilities/TimeTest.cpp
@@ -25,14 +25,24 @@
 
 using namespace LEDSpicer::Utilities;
 
-TEST(TimeTest, ConstructorZeroSeconds) {
+class TimeTest : public ::testing::Test {
+
+protected:
+	void SetUp() override {
+		Time::setFrameTime();
+	}
+};
+
+TEST_F(TimeTest, ConstructorZeroSeconds) {
+	Time::setFrameTime();
 	// Immediate expiration.
 	EXPECT_TRUE(Time(0).isTime());
 	Time time;
 	EXPECT_TRUE(time.isTime());
 }
 
-TEST(TimeTest, IsTimeExpiration) {
+TEST_F(TimeTest, IsTimeExpiration) {
+	Time::setFrameTime();
 	// 2 seconds.
 	Time timeObj(2);
 	EXPECT_FALSE(timeObj.isTime()); // Not yet.
@@ -44,7 +54,8 @@ TEST(TimeTest, IsTimeExpiration) {
 	EXPECT_TRUE(timeObj.isTime());
 }
 
-TEST(TimeTest, MultipleTimersIndependent) {
+TEST_F(TimeTest, MultipleTimersIndependent) {
+	Time::setFrameTime();
 	Time timeShort(1);
 	Time timeLong(3);
 	sleep_for(std::chrono::milliseconds(1500)); // Wait 1.5s.
@@ -54,7 +65,8 @@ TEST(TimeTest, MultipleTimersIndependent) {
 	EXPECT_TRUE(timeLong.isTime());
 }
 
-TEST(TimeTest, ResetTimer) {
+TEST_F(TimeTest, ResetTimer) {
+	Time::setFrameTime();
 	Time timeObj(1);
 	sleep_for(std::chrono::milliseconds(500));
 	timeObj.reset(1000);


### PR DESCRIPTION
## Release candidate 0.7.4

### Added
- `restartTime` parameter for actors: delay before restarting after `endTime` expires
- Time is now frame-based, syncing multiple actors to the same point in time

### Changed
- Time and duration values now accept decimals (e.g. `1.5` seconds)
- Repeat limit increased from 255 to 65535
- Improved actor runtime validation
- `checkRepeats()` infinite repeat behaviour corrected

### Removed
- `cycles` parameter from FrameActor, replaced by `endTime`

### Fixed
- Serpentine animation debug log showed wrong position
- Element reset loop applied incorrectly in some cases