### PR TITLE
Fix/cache miss with crafted

### DIFF
--- a/src/DataLoader.cpp
+++ b/src/DataLoader.cpp
@@ -397,18 +397,15 @@ void DataLoader::processGroupElements(tinyxml2::XMLElement* groupNode, Group& gr
 }
 
 Profile* DataLoader::getProfileFromCache(const string& name) {
-	if (not profilesCache.exists(name)) {
-		LogDebug("Profile cache miss");
-		return nullptr;
-	}
-
-	auto profile(profilesCache.at(name));
-	LogDebug("Profile from cache");
-	return profile;
+	if (not profilesCache.exists(name)) return nullptr;
+	return profilesCache.at(name);
 }
 
-Profile* DataLoader::processProfile(const string& name, const string& extra) {
+Profile* DataLoader::processProfile(const string& name, const string& cacheKey) {
 
+	// `name` is the file to read; `key` is the cache key and profile name (defaults to the file).
+	// Crafted profiles read a shared platform template but cache under a per-game key.
+	const string& key {cacheKey.empty() ? name : cacheKey};
 	XMLHelper profile(getProjectDir() + createFilename(PROFILE_DIR + name), "Profile");
 	StringUMap tempAttr = processNode(profile.getRoot());
 	Utility::checkAttributes(REQUIRED_PARAM_PROFILE, tempAttr, "root");
@@ -422,7 +419,7 @@ Profile* DataLoader::processProfile(const string& name, const string& extra) {
 		Utility::checkAttributes(REQUIRED_PARAM_NAME_ONLY, tempAttr, "transition for profile " + name);
 		transition = tempAttr[PARAM_NAME];
 	}
-	Profile* profilePtr = new Profile(name, Color::getColor(backgroundColor));
+	Profile* profilePtr = new Profile(key, Color::getColor(backgroundColor));
 	processTransition(profilePtr, tempAttr);
 
 	// Check for animations.
@@ -484,11 +481,8 @@ Profile* DataLoader::processProfile(const string& name, const string& extra) {
 		}
 	}
 
-	// Save Cache, replace previous value if any.
-	if (profilesCache.exists(name + extra)) {
-		delete profilesCache[name + extra];
-	}
-	profilesCache[name + extra] = profilePtr;
+	// A replaced profile may still be referenced; the caller frees it after repointing.
+	profilesCache[key] = profilePtr;
 	return profilePtr;
 }
 

--- a/src/DataLoader.hpp
+++ b/src/DataLoader.hpp
@@ -170,12 +170,13 @@ public:
 	static Profile* getProfileFromCache(const string& name);
 
 	/**
-	 * Reads a profile file form disk or cache.
-	 * @param name
-	 * @param extra, if set will use it to differentiate from other profiles with the same name, only used while crafting profiles.
+	 * Reads and builds a profile from disk, storing it in the cache.
+	 * @param name the profile file to read.
+	 * @param cacheKey cache key and profile name; defaults to the file name. Crafted profiles
+	 *        read a shared platform template (name) but cache under a per-game key.
 	 * @throws Error if the profile is invalid.
 	 */
-	static Profile* processProfile(const string& name, const string& extra = "");
+	static Profile* processProfile(const string& name, const string& cacheKey = "");
 
 	/**
 	 * Adds a transition into the cache.

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -240,7 +240,7 @@ void Main::run() {
 			storeProfile = true;
 			if (not newProfile) {
 				// Craft profile.
-				newProfile = craftProfile(msg.getData()[3], msg.getData()[1], msg.getData()[2]);
+				newProfile = craftProfile(msg.getData()[0], msg.getData()[3], msg.getData()[1], msg.getData()[2]);
 				// Try platform profile.
 				if (not newProfile) newProfile = tryProfiles({msg.getData()[3]});
 			}
@@ -443,132 +443,117 @@ int main(int argc, char **argv) {
 }
 
 Profile* Main::tryProfiles(const vector<string>& data) {
-	Profile
-		// New profile to load.
-		* profile    = nullptr,
-		// Old profile from cache, if any.
-		* oldProfile = nullptr;
-
-	// If there is a profile and reload flag, reload it (used for debug).
-	bool reload(Utility::globalFlags & FLAG_FORCE_RELOAD);
-	for (auto& profileName : data) {
+	// Reload (used for debugging) ignores the cache and rebuilds the profile in place.
+	const bool reload {(Utility::globalFlags & FLAG_FORCE_RELOAD) != 0};
+	for (const auto& profileName : data) {
 		LogDebug("Attempting to load profile: " + profileName);
 		try {
-			// Check cache to get the old version (if any).
-			oldProfile = DataLoader::getProfileFromCache(profileName);
-
-			// Reload is normally used for debugging profiles.
-			if (reload) {
-				LogDebug("Ignoring cache, reloading profile");
-				// Reload or cache miss is the same, but if exist it will be replaced.
-				profile = DataLoader::processProfile(profileName);
-				// Update any reference.
-				if (oldProfile) {
-					DataLoader::removeTransitionFromCache(oldProfile, true);
-					// Check default profile and current profile.
-					if (oldProfile == Profile::defaultProfile) Profile::defaultProfile = profile;
-					if (oldProfile == currentProfile) currentProfile = profile;
-					// Also update all copies before delete.
-					for (auto &p : profiles) if (p == oldProfile) p = profile;
-				}
-				return profile;
+			Profile* old {DataLoader::getProfileFromCache(profileName)};
+			if (old and not reload) {
+				LogDebug("Profile " + profileName + " from cache");
+				return old;
 			}
-
-			if (oldProfile) return oldProfile;
-			return DataLoader::processProfile(profileName);
+			Profile* profile {DataLoader::processProfile(profileName)};
+			replaceProfileReferences(old, profile);
+			return profile;
 		}
-		catch(Error& e) {
+		catch (Error& e) {
 			LogDebug("Profile failed: " + e.getMessage());
 			continue;
 		}
 	}
-	return profile;
+	return nullptr;
 }
 
-Profile* Main::craftProfile(const string& name, const string& elements, const string& groups) {
+void Main::replaceProfileReferences(Profile* old, Profile* neu) {
+	if (not old or old == neu) return;
+	DataLoader::removeTransitionFromCache(old, true);
+	if (old == Profile::defaultProfile) Profile::defaultProfile = neu;
+	if (old == currentProfile)          currentProfile = neu;
+	// Update all stack copies before freeing the replaced profile.
+	for (auto& p : profiles) if (p == old) p = neu;
+	delete old;
+}
 
-	Profile* profile(nullptr);
-	string profileName(name + elements + groups);
+Profile* Main::craftProfile(const string& name, const string& platform, const string& elements, const string& groups) {
+
+	// Crafted profiles are cached per game; reload rebuilds in place.
+	const string cacheKey {EMPTY_PROFILE + name};
+	const bool reload {(Utility::globalFlags & FLAG_FORCE_RELOAD) != 0};
 	try {
-		// Check cache.
-		profile = DataLoader::getProfileFromCache(profileName);
-		if (not profile) {
-			LogDebug("Creating profile with " EMPTY_PROFILE + name);
-			profile = DataLoader::processProfile(EMPTY_PROFILE + name, elements + groups);
-			// Add elements.
-			LogDebug("Adding elements");
-			for (string& n : Utility::explode(elements, FIELD_SEPARATOR)) {
-				const Color* col = nullptr;
-				auto parts = Utility::explode(n, GROUP_SEPARATOR);
-				n = parts[0];
-				if (not Element::allElements.exists(n)) {
-					LogDebug("Unknown element " + n);
-					continue;
-				}
-				if (parts.size() == 2 and Color::hasColor(parts[1]))
-					col = &Color::getColor(parts[1]);
-				else
-					col = &Element::allElements.at(n)->getDefaultColor();
+		Profile* old {DataLoader::getProfileFromCache(cacheKey)};
+		if (old and not reload) {
+			LogDebug("Profile " + cacheKey + " from cache");
+			return old;
+		}
 
-				LogDebug("Using element " + n + " color " + col->getName());
-				profile->addAlwaysOnElement(Element::allElements.at(n), *col, Color::Filters::Normal);
+		LogDebug("Crafting " + cacheKey + " from " EMPTY_PROFILE + platform);
+		Profile* profile {DataLoader::processProfile(EMPTY_PROFILE + platform, cacheKey)};
+
+		// Add elements.
+		LogDebug("Adding elements");
+		for (string& n : Utility::explode(elements, FIELD_SEPARATOR)) {
+			const Color* col = nullptr;
+			auto parts = Utility::explode(n, GROUP_SEPARATOR);
+			n = parts[0];
+			if (not Element::allElements.exists(n)) {
+				LogDebug("Unknown element " + n);
+				continue;
 			}
+			if (parts.size() == 2 and Color::hasColor(parts[1]))
+				col = &Color::getColor(parts[1]);
+			else
+				col = &Element::allElements.at(n)->getDefaultColor();
 
-			// Add Groups.
-			/*
-			LogDebug("Adding groups");
-			for (string& n : Utility::explode(groups, FIELD_SEPARATOR)) {
-				LogDebug("Using group " + n);
-				if (Group::layout.exists(n)) {
-					profile->addAlwaysOnGroup(
-						&Group::layout.at(n), DataLoader::allElements.at(n)->getDefaultColor()
-					);
-				}
-				else {
-					LogDebug(n + " failed");
-				}
+			LogDebug("Using element " + n + " color " + col->getName());
+			profile->addAlwaysOnElement(Element::allElements.at(n), *col, Color::Filters::Normal);
+		}
+
+		// Add Animations.
+		LogDebug("Adding Animations");
+		for (string& n : Utility::explode(groups, FIELD_SEPARATOR)) {
+			LogDebug("Loading animation " + n);
+			try {
+				profile->addAnimation(DataLoader::processAnimation(n));
 			}
-			*/
-
-			// Add Animations.
-			LogDebug("Adding Animations");
-			for (string& n : Utility::explode(groups, FIELD_SEPARATOR)) {
-				LogDebug("Loading animation " + n);
-				try {
-					profile->addAnimation(DataLoader::processAnimation(n));
-				}
-				catch (...) {
-					LogDebug(n + " failed");
-					continue;
-				}
-			}
-
-			// Add Inputs.
-			LogDebug("Adding Inputs");
-			for (string& n : Utility::explode(groups, FIELD_SEPARATOR)) {
-				LogDebug("Loading input " + n);
-				try {
-					DataLoader::processInput(profile, n);
-				}
-				catch (...) {
-					LogDebug(n + " failed");
-					continue;
-				}
+			catch (...) {
+				LogDebug(n + " failed");
+				continue;
 			}
 		}
+
+		// Add Inputs.
+		LogDebug("Adding Inputs");
+		for (string& n : Utility::explode(groups, FIELD_SEPARATOR)) {
+			LogDebug("Loading input " + n);
+			try {
+				DataLoader::processInput(profile, n);
+			}
+			catch (...) {
+				LogDebug(n + " failed");
+				continue;
+			}
+		}
+
+		replaceProfileReferences(old, profile);
+		return profile;
 	}
 	catch (Error& e) {
 		LogNotice(e.getMessage());
+		return nullptr;
 	}
-	return profile;
 }
 
 void Main::changeProfile(Profile* to, bool store) {
 	// TODO add benchmark timers
 	// If there is a profile and replace flag, replace current profile.
-	bool replace(profiles.size() and (Utility::globalFlags & FLAG_REPLACE));
+	bool replace {profiles.size() and (Utility::globalFlags & FLAG_REPLACE)};
 	if (to) {
-		LogInfo((replace ? "Replacing Profile " + currentProfile->getName() + " with " : "Changing profile " + currentProfile->getName() + " with ") + to->getName());
+		LogInfo((
+			(Utility::globalFlags & FLAG_FORCE_RELOAD) ? "Reloading profile " :
+			replace                                    ? "Replacing profile " :
+			                                             "Changing profile ")
+			+ currentProfile->getName() + " with " + to->getName());
 	}
 	else {
 		LogInfo("Terminating Profile " + currentProfile->getName());
@@ -593,8 +578,18 @@ void Main::changeProfile(Profile* to, bool store) {
 		if (to) to->reset();
 	}
 
-	if (replace) profiles.pop_back();
-	if (store) profiles.push_back(to);
+	// Stack maintenance (RELOAD already refreshed every matching instance from disk during fetch):
+	//  - REPLACE swaps the top with the new profile, unless the top is already the same profile;
+	//  - otherwise the load is pushed onto the history stack.
+	if (store) {
+		if (replace) {
+			if (profiles.back() != to) {
+				profiles.pop_back();
+				profiles.push_back(to);
+			}
+		}
+		else profiles.push_back(to);
+	}
 	currentProfile = to;
 	if (to and not (Utility::globalFlags & FLAG_NO_INPUTS)) to->startInputs();
 	Utility::globalFlags = 0;

--- a/src/Main.hpp
+++ b/src/Main.hpp
@@ -61,12 +61,20 @@ protected:
 	Profile* tryProfiles(const vector<string>& data);
 
 	/**
-	 * Attempts create a profile with the values provided.
-	 * Will check cache for an existing profile first.
-	 * @param name
-	 * @return the new crafted profile or null if failed.
+	 * Crafts a profile from a platform template plus the requested elements/animations/inputs.
+	 * Cached per game; honours FLAG_FORCE_RELOAD to rebuild in place.
+	 * @param name the full game name, used as the cache key (e.g. arcade/1943).
+	 * @param platform the platform template to build from (e.g. arcade).
+	 * @return the crafted profile or null if failed.
 	 */
-	Profile* craftProfile(const string& name, const string& elements, const string& groups);
+	Profile* craftProfile(const string& name, const string& platform, const string& elements, const string& groups);
+
+	/**
+	 * Repoints every reference (default, current, profile stack) from old to neu and frees old.
+	 * No-op when old is null or equal to neu. Used after a rebuild so the replaced profile is
+	 * freed only once nothing points at it.
+	 */
+	void replaceProfileReferences(Profile* old, Profile* neu);
 
 	/**
 	 * Initiates the process or replacing the current profile.


### PR DESCRIPTION
Fix crash and cache handling for crafted profiles

- Fix use-after-free crash when loading the same crafted profile twice
- Cache and retrieve crafted profiles by game name (were rebuilt every request)
- Apply FORCE_RELOAD and REPLACE flags correctly on the craft/load path
- Restore profile stack history so FinishLastProfile steps back one at a time