### PR TITLE
123: Rotator: argument parsing crashes and a redundant init

### DIFF
--- a/src/DataLoader.cpp
+++ b/src/DataLoader.cpp
@@ -141,6 +141,43 @@ void DataLoader::processDevices() {
 	}
 }
 
+void DataLoader::parseColorOrder(
+	const string& colorFormat,
+	uint16_t& c,
+	uint16_t& r,
+	uint16_t& g,
+	uint16_t& b,
+	vector<bool>& ledCheck,
+	const string& location
+) {
+	// Must be a permutation of the three channels, one each, case insensitive.
+	if (colorFormat.size() != 3
+		or colorFormat.find_first_not_of("RGBrgb") != string::npos
+		or colorFormat.find_first_of("Rr") == string::npos
+		or colorFormat.find_first_of("Gg") == string::npos
+		or colorFormat.find_first_of("Bb") == string::npos)
+		throw Utilities::Error("Color format must be a permutation of R, G and B, got '" + colorFormat + "' in " + location);
+	for (char col : colorFormat) {
+		switch (col) {
+		case 'R':
+		case 'r':
+			ledCheck[c] = true;
+			r = c++;
+			break;
+		case 'G':
+		case 'g':
+			ledCheck[c] = true;
+			g = c++;
+			break;
+		case 'B':
+		case 'b':
+			ledCheck[c] = true;
+			b = c++;
+			break;
+		}
+	}
+}
+
 void DataLoader::processDeviceElements(tinyxml2::XMLElement* deviceNode, Device* device) {
 
 	// Only used to report unused LEDs.
@@ -207,8 +244,8 @@ void DataLoader::processDeviceElements(tinyxml2::XMLElement* deviceNode, Device*
 				// 1st RGB element
 				pos  ((Utility::parseNumber(tempAttr[PARAM_POSITION], invalidValueFor(PARAM_POSITION) " in " + device->getFullName()) - 1) * 3),
 				elem (1);
-			string
-				order(tempAttr.exists(PARAM_COLORFORMAT) ? tempAttr.at(PARAM_COLORFORMAT) : DEFAULT_ORDER),
+			const string
+				rgbFormat(tempAttr.exists(PARAM_COLORFORMAT) ? tempAttr.at(PARAM_COLORFORMAT) : DEFAULT_ORDER),
 				groupName(name);
 			// Create a group for the strip only.
 			if (size > 3)
@@ -222,22 +259,7 @@ void DataLoader::processDeviceElements(tinyxml2::XMLElement* deviceNode, Device*
 			// Process element(s)
 			for (uint16_t c = pos; c < pos + size; ++elem) {
 				string elemName(name + (size > 3 ? to_string(elem) : ""));
-				for (char col : order) {
-					switch (col) {
-					case 'r':
-						ledCheck[c] = true;
-						r = c++;
-						break;
-					case 'g':
-						ledCheck[c] = true;
-						g = c++;
-					break;
-					case 'b':
-						ledCheck[c] = true;
-						b = c++;
-					break;
-					}
-				}
+				parseColorOrder(rgbFormat, c, r, g, b, ledCheck, device->getFullName());
 				device->registerElement(
 					elemName,
 					r, g , b,
@@ -265,23 +287,7 @@ void DataLoader::processDeviceElements(tinyxml2::XMLElement* deviceNode, Device*
 				if (not Utility::verifyValue<uint16_t>(pos, 0, device->getNumberOfElements())) {
 					throw Utilities::Error("Invalid value " + posStr + " in " + tempAttr.at(PARAM_POSITIONS) + " for element " + name + " in " + device->getFullName());
 				}
-				// Process element(s)
-				for (char col : order) {
-					switch (col) {
-					case 'r':
-						ledCheck[c] = true;
-						r = c++;
-						break;
-					case 'g':
-						ledCheck[c] = true;
-						g = c++;
-					break;
-					case 'b':
-						ledCheck[c] = true;
-						b = c++;
-					break;
-					}
-				}
+				parseColorOrder(order, c, r, g, b, ledCheck, name + " in " + device->getFullName());
 				ledPositions.push_back(r);
 				ledPositions.push_back(g);
 				ledPositions.push_back(b);

--- a/src/DataLoader.hpp
+++ b/src/DataLoader.hpp
@@ -301,6 +301,28 @@ protected:
 	void processDeviceElements(tinyxml2::XMLElement* deviceNode, Device* device);
 
 	/**
+	 * Resolves a colorFormat order (a permutation of R, G and B, case
+	 * insensitive) into the three channel LED indices, advancing the running
+	 * index and marking every consumed LED.
+	 * @param colorFormat the channel order, e.g. "RGB" or "grb"
+	 * @param c running LED index, advanced by 3
+	 * @param r set to the red channel LED index
+	 * @param g set to the green channel LED index
+	 * @param b set to the blue channel LED index
+	 * @param ledCheck per LED used flags, marked for each channel
+	 * @param location context appended to error messages
+	 */
+	static void parseColorOrder(
+		const string& colorFormat,
+		uint16_t& c,
+		uint16_t& r,
+		uint16_t& g,
+		uint16_t& b,
+		vector<bool>& ledCheck,
+		const string& location
+	);
+
+	/**
 	 * Reads the layout and group sections from config.
 	 * @return the default layout properties.
 	 */

--- a/src/Rotator.cpp
+++ b/src/Rotator.cpp
@@ -97,21 +97,31 @@ int main(int argc, char **argv) {
 
 		// Reset Only.
 		if (commandline == "-r" or commandline == "--reset") {
+			if (i + 1 >= argc) {
+				LogError("Missing value for " + commandline);
+				return EXIT_FAILURE;
+			}
 			resetWays = argv[++i];
 			continue;
 		}
 
 		// Alternative configuration.
 		if (commandline == "-c" or commandline == "--config") {
+			if (i + 1 >= argc) {
+				LogError("Missing value for " + commandline);
+				return EXIT_FAILURE;
+			}
 			configFile = argv[++i];
 			continue;
 		}
 
-		if ((i + 2) > argc) {
+		if ((i + 2) >= argc) {
 			LogError("Invalid player data");
 			return EXIT_FAILURE;
 		}
-		playersRequestedData.emplace(commandline + "_" + argv[i + 1], Restrictor::str2ways(argv[i + 2]));
+		const string key(commandline + "_" + argv[i + 1]);
+		if (not playersRequestedData.emplace(key, Restrictor::str2ways(argv[i + 2])).second)
+			LogWarning("Duplicate request for " + Restrictor::getProfileStr(key) + ", ignoring the second value");
 		i+=2;
 	}
 
@@ -119,8 +129,6 @@ int main(int argc, char **argv) {
 		LogError("Nothing to do");
 		return EXIT_SUCCESS;
 	}
-
-	Log::initialize(true);
 
 	if (configFile.empty())
 		configFile = CONFIG_FILE;
@@ -179,6 +187,7 @@ int main(int argc, char **argv) {
 				// Set Rotations.
 				if (playersRequestedData.size() and playersRequestedData.exists(pd.first)) {
 					availablePlayersData.emplace(pd.first, playersRequestedData.at(pd.first));
+					playersRequestedData.erase(pd.first);
 				}
 				// Reset all.
 				else if (resetWays.size()) {
@@ -199,7 +208,9 @@ int main(int argc, char **argv) {
 			delete restrictor;
 			sleep_for(std::chrono::milliseconds(250));
 		}
-
+		// Anything left was requested but matched no restrictor.
+		for (const auto& pd : playersRequestedData)
+			LogWarning(Restrictor::getProfileStr(pd.first) + " requested but not found in any restrictor");
 	}
 	catch(Error& e) {
 		LogError("Error: " + e.getMessage());

--- a/src/devices/Adalight/Adalight.cpp
+++ b/src/devices/Adalight/Adalight.cpp
@@ -58,7 +58,7 @@ void Adalight::transfer() const {
 
 	// Data
 	serialData.insert(serialData.end(), LEDs.begin(), LEDs.begin() + numIndividualLeds);
-
+	serialData.push_back('\0');
 
 	transferToConnection(serialData);
 	/* for testing:*/

--- a/src/utilities/Serial.cpp
+++ b/src/utilities/Serial.cpp
@@ -155,7 +155,6 @@ void Serial::disconnect() {
 }
 
 void Serial::transferToConnection(vector<uint8_t>& data) const {
-	data.push_back('\0');
 	Connection::transferToConnection(data);
 	size_t totalWritten = 0;
 	while (totalWritten < data.size()) {


### PR DESCRIPTION
Task-Url: https://github.com/meduzapat/LEDSpicer/issues/123

All issues fixed
* Fixes the issue for non working TOS serial restrictor
* Renames for a confusing variable
* Now color format uses RGB or rgb
* Harden colorFormat parsing and warn on duplicate rotator requests.
* warns when the same player/joystick triplet is given twice instead of silently dropping the duplicate.
* Improved error messages.