### PR TITLE
125: Daemon must start independent of user session and audio (lazy audio

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -408,7 +408,7 @@ add_custom_target(uninstall
 file(WRITE ${CMAKE_BINARY_DIR}/ledspicerd.service
 	"[Unit]\n"
 	"Description=LEDSpicer Daemon\n"
-	"After=network.target sound.target\n"
+	"After=network.target\n"
 	"StartLimitIntervalSec=60s\n"
 	"StartLimitBurst=3\n\n"
 
@@ -419,18 +419,6 @@ file(WRITE ${CMAKE_BINARY_DIR}/ledspicerd.service
 	"RestartSec=5s\n"
 	"ExecStop=/bin/kill -TERM $MAINPID\n"
 	"TimeoutStopSec=15s\n"
-)
-
-# Optional PulseAudio support
-if(ENABLE_PULSEAUDIO)
-	file(APPEND ${CMAKE_BINARY_DIR}/ledspicerd.service
-		"# Optional PulseAudio socket hint (daemon reconnects if unavailable) remember to change 1000 with the used ID if different\n"
-		"Environment=PULSE_SERVER=unix:/run/user/1000/pulse/native\n"
-	)
-endif()
-
-# Base service file bottom part.
-file(APPEND ${CMAKE_BINARY_DIR}/ledspicerd.service
 	"\n"
 	"[Install]\n"
 	"WantedBy=multi-user.target\n"

--- a/src/animations/AlsaAudio.cpp
+++ b/src/animations/AlsaAudio.cpp
@@ -26,35 +26,41 @@ using namespace LEDSpicer::Animations;
 
 using LEDSpicer::Devices::Group;
 
-snd_pcm_t* AlsaAudio::pcm    = nullptr;
+snd_pcm_t* AlsaAudio::pcm     = nullptr;
 uint8_t AlsaAudio::instances = 0;
+string AlsaAudio::pcmName;
 
 AlsaAudio::AlsaAudio(StringUMap& parameters, Group* const group) :
 	AudioActor(parameters, group) {
 
 	++instances;
+	if (pcm) return;
 
-	LogInfo("Connecting to ALSA " SND_LIB_VERSION_STR);
+	if (pcmName.empty())
+		pcmName = parameters.exists("pcm") ? parameters["pcm"] : "default";
 
-	if (pcm) {
-		LogInfo("Reusing ALSA connection");
-		return;
-	}
+	// Does not throw: calcPeak retries if the device is not ready or later drops.
+	connect();
+}
 
-	string PCM = parameters.exists("pcm") ? parameters["pcm"] : "default";
+AlsaAudio::~AlsaAudio() {
+	if (--instances) return;
+	disconnect();
+}
+
+bool AlsaAudio::connect() {
 
 	int err;
-	// Open with non-blocking flag
-	if ((err = snd_pcm_open(&pcm, PCM.c_str(), SND_PCM_STREAM_CAPTURE, SND_PCM_NONBLOCK)) < 0)
-		throw Error("Unable to open ") << PCM << ": " << snd_strerror(err);
+	// Non-blocking so a missing device fails fast.
+	if ((err = snd_pcm_open(&pcm, pcmName.c_str(), SND_PCM_STREAM_CAPTURE, SND_PCM_NONBLOCK)) < 0) {
+		LogDebug("Unable to open " + pcmName + ": " + snd_strerror(err));
+		pcm = nullptr;
+		return false;
+	}
 
-	// Calculate latency based on FPS
-	// Frame time = 1000ms / FPS
-	uint32_t frameTimeMs = 1000 / getFPS();
-	// Buffer should be 2-3x frame time to prevent underruns
-	uint32_t bufferLatencyUs = frameTimeMs * 2500;
+	// Buffer should be 2-3x the frame time to prevent underruns.
+	uint32_t bufferLatencyUs = (1000 / getFPS()) * 2500;
 
-	// Set basic parameters with appropriate latency
 	if ((err = snd_pcm_set_params(
 		pcm,
 		SND_PCM_FORMAT_S16_LE,
@@ -63,30 +69,40 @@ AlsaAudio::AlsaAudio(StringUMap& parameters, Group* const group) :
 		SAMPLE_RATE,
 		0,  // No resampling
 		bufferLatencyUs
-	)) < 0)
-		throw Error("Unable to set parameters for " + PCM + ": " + string(snd_strerror(err)));
-	// Explicitly prepare the PCM
-	if ((err = snd_pcm_prepare(pcm)) < 0)
-		throw Error("Unable to prepare PCM: " + string(snd_strerror(err)));
+	)) < 0) {
+		LogDebug("Unable to set parameters for " + pcmName + ": " + string(snd_strerror(err)));
+		disconnect();
+		return false;
+	}
 
-	// Start capture
-	if ((err = snd_pcm_start(pcm)) < 0)
-		throw Error("Unable to start PCM: " + string(snd_strerror(err)));
+	if ((err = snd_pcm_prepare(pcm)) < 0) {
+		LogDebug("Unable to prepare PCM: " + string(snd_strerror(err)));
+		disconnect();
+		return false;
+	}
 
-	LogInfo("ALSA connected");
+	if ((err = snd_pcm_start(pcm)) < 0) {
+		LogDebug("Unable to start PCM: " + string(snd_strerror(err)));
+		disconnect();
+		return false;
+	}
+
+	LogInfo("ALSA connected to " + pcmName);
+	return true;
 }
 
-AlsaAudio::~AlsaAudio() {
-	--instances;
-	if (instances > 0) return;
-
-	LogInfo("Closing ALSA");
+void AlsaAudio::disconnect() {
+	if (not pcm) return;
 	snd_pcm_drop(pcm);
 	snd_pcm_close(pcm);
 	pcm = nullptr;
 }
 
 void AlsaAudio::calcPeak() {
+
+	// Reconnect after a device loss; skip the frame while unavailable.
+	if (not pcm and not connect()) return;
+
 	// Calculate how many samples we need based on FPS
 	// This gives us "fresh" audio data matching our update rate
 	static const uint16_t samplesNeeded = (SAMPLE_RATE / getFPS()); // e.g., 48000/30 = 1600 samples
@@ -107,9 +123,10 @@ void AlsaAudio::calcPeak() {
 		return;
 	}
 
-	// Bail on other errors
+	// Device gone: drop so the next frame reconnects.
 	if (frames < 0) {
-		LogInfo("ALSA error: " + string(snd_strerror(frames)));
+		LogWarning("ALSA error: " + string(snd_strerror(frames)) + ", reconnecting");
+		disconnect();
 		return;
 	}
 

--- a/src/animations/AlsaAudio.hpp
+++ b/src/animations/AlsaAudio.hpp
@@ -58,6 +58,20 @@ protected:
 	/// Shared PCM handle for audio capture.
 	static snd_pcm_t* pcm;
 
+	/// Capture device name, set by the first instance.
+	static string pcmName;
+
+	/**
+	 * Opens and starts the capture device.
+	 * @return true if the device is ready, false on any failure (left closed).
+	 */
+	static bool connect();
+
+	/**
+	 * Closes the capture device if open.
+	 */
+	static void disconnect();
+
 	void calcPeak() override;
 };
 

--- a/src/animations/PulseAudio.cpp
+++ b/src/animations/PulseAudio.cpp
@@ -47,7 +47,14 @@ PulseAudio::PulseAudio(StringUMap& parameters, Group* const group) :
 		return;
 	}
 
-	connect();
+	// Must not abort load: on failure fall back to the background retry.
+	try {
+		connect();
+	}
+	catch (Error& e) {
+		LogWarning("PulseAudio connection failed: " + e.getMessage() + ", will keep retrying");
+		scheduleReconnect();
+	}
 }
 
 PulseAudio::~PulseAudio() {
@@ -82,9 +89,14 @@ void PulseAudio::connect() {
 	}
 
 	pa_context_set_state_callback(context, PulseAudio::onContextSetState, nullptr);
-	pa_context_connect(context, nullptr, PA_CONTEXT_NOFLAGS, nullptr);
+
+	// Derive the user's socket from the effective uid (already dropped to it).
+	// PULSE_SERVER overrides.
+	const char* envServer = getenv("PULSE_SERVER");
+	string server(envServer ? "" : "unix:/run/user/" + to_string(getuid()) + "/pulse/native");
+	pa_context_connect(context, envServer ? nullptr : server.c_str(), PA_CONTEXT_NOFLAGS, nullptr);
 	pa_threaded_mainloop_start(tml);
-	LogDebug("PulseAudio connection initiated");
+	LogDebug("PulseAudio connecting to " + (envServer ? string(envServer) : server));
 }
 
 void PulseAudio::disconnect() {


### PR DESCRIPTION
connection + portable cross-session PulseAudio access)

Task-Url: https://github.com/meduzapat/LEDSpicer/issues/125

* The daemon must come up as soon as the network is ready, before any user session, and never fail to load because audio is not available yet.

* ALSA: open the capture device in the constructor without throwing; if the device is not present or is later lost (read error), calcPeak drops the handle and reopens on the next frame. connect()/disconnect() extracted.

* PulseAudio: an initial connection failure in the constructor falls back to the existing background retry instead of throwing. The per-user socket is derived from the effective uid (privileges are already dropped to the configured user) and passed explicitly to pa_context_connect. PULSE_SERVER still overrides.

* service file: drop sound.target from After= (audio is lazy) and remove the PULSE_SERVER entry entirely (the daemon derives the socket itself).