### PR TITLE
Release 0.7.7

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,80 @@
+name: Publish release packages
+
+# Fires after a GitHub Release is published, i.e. once the tag and its source
+# tarball exist. That ordering matters: both the AUR PKGBUILD checksum and the
+# Fedora spec's Source0 point at .../archive/refs/tags/<version>.tar.gz, which
+# only exists after the Release is cut.
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # AUR: regenerate PKGBUILD/.SRCINFO with the real checksum and push to the AUR
+  # repo. Runs on a stock runner because generate-changelogs.sh templates
+  # .SRCINFO itself (no makepkg / Arch container needed).
+  # ---------------------------------------------------------------------------
+  aur:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the released tag
+        uses: actions/checkout@v6
+
+      - name: Verify the AUR key is configured
+        run: |
+          if [ -z "${{ secrets.AUR_SSH_PRIVATE_KEY }}" ]; then
+            echo "::error::AUR_SSH_PRIVATE_KEY secret is not set."
+            exit 1
+          fi
+
+      - name: Generate PKGBUILD and .SRCINFO with the real checksum
+        run: |
+          ./packaging/generate-changelogs.sh
+          if grep -q "SKIP" packaging/arch/PKGBUILD; then
+            echo "::error::Checksum is still SKIP - the tag tarball was not reachable."
+            exit 1
+          fi
+
+      - name: Publish to AUR
+        env:
+          AUR_SSH_PRIVATE_KEY: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+          VERSION: ${{ github.event.release.tag_name }}
+        run: |
+          mkdir -p ~/.ssh
+          printf '%s\n' "$AUR_SSH_PRIVATE_KEY" > ~/.ssh/aur
+          chmod 600 ~/.ssh/aur
+          ssh-keyscan -H aur.archlinux.org >> ~/.ssh/known_hosts 2>/dev/null
+          export GIT_SSH_COMMAND="ssh -i ~/.ssh/aur -o IdentitiesOnly=yes"
+
+          git clone ssh://aur@aur.archlinux.org/ledspicer.git aur-repo
+          cp packaging/arch/PKGBUILD  aur-repo/PKGBUILD
+          cp packaging/arch/.SRCINFO aur-repo/.SRCINFO
+
+          cd aur-repo
+          if git diff --quiet; then
+            echo "Nothing changed in the AUR repo; skipping push."
+            exit 0
+          fi
+          git config user.name  "LEDSpicer release bot"
+          git config user.email "meduzapat@nescape.net"
+          git add PKGBUILD .SRCINFO
+          git commit -m "Update to ${VERSION}"
+          git push
+
+  # ---------------------------------------------------------------------------
+  # COPR: poke the custom webhook so Fedora rebuilds from the (now-tagged) repo.
+  # Independent of the AUR job so one failing distro never blocks the other.
+  # ---------------------------------------------------------------------------
+  copr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger the COPR build
+        run: |
+          if [ -z "${{ secrets.COPR_WEBHOOK_URL }}" ]; then
+            echo "::error::COPR_WEBHOOK_URL secret is not set."
+            exit 1
+          fi
+          curl -X POST --fail-with-body -sS "${{ secrets.COPR_WEBHOOK_URL }}"

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ CMakeCache.txt
 #tests/tests*
 ledspicerd.service
 ledspicer.pc
+src/config.hpp
 
 # Compiled Dynamic libraries
 *.so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to LEDSpicer will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.7] - 2026-06-30
+
+### Added
+- Automated release publishing to COPR and AUR.
+
+### Changed
+- Daemon starts independently of the user session and audio; audio now connects lazily so the service comes up as soon as the network is ready (#125)
+- systemd service no longer waits on `sound.target` and no longer sets `PULSE_SERVER` — the daemon derives the per-user PulseAudio socket itself (#125)
+- CMake build cleanups and definition fixes; generated `config.hpp`
+
+### Fixed
+- ALSA capture device opens without throwing and reopens automatically if it is missing or later lost (#125)
+- PulseAudio falls back to the background retry on an initial connection failure instead of aborting startup (#125)
+- Rotator argument-parsing crash and a redundant initialization (#123)
+- Non-working TOS serial restrictor (#123)
+- Hardened `colorFormat` parsing (accepts `RGB`/`rgb`) and now warns on duplicate player/joystick rotator requests instead of silently dropping them (#123)
+
 ## [0.7.6] - 2026-06-14
 
 ### Fixed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -408,7 +408,7 @@ add_custom_target(uninstall
 file(WRITE ${CMAKE_BINARY_DIR}/ledspicerd.service
 	"[Unit]\n"
 	"Description=LEDSpicer Daemon\n"
-	"After=network.target sound.target\n"
+	"After=network.target\n"
 	"StartLimitIntervalSec=60s\n"
 	"StartLimitBurst=3\n\n"
 
@@ -419,18 +419,6 @@ file(WRITE ${CMAKE_BINARY_DIR}/ledspicerd.service
 	"RestartSec=5s\n"
 	"ExecStop=/bin/kill -TERM $MAINPID\n"
 	"TimeoutStopSec=15s\n"
-)
-
-# Optional PulseAudio support
-if(ENABLE_PULSEAUDIO)
-	file(APPEND ${CMAKE_BINARY_DIR}/ledspicerd.service
-		"# Optional PulseAudio socket hint (daemon reconnects if unavailable) remember to change 1000 with the used ID if different\n"
-		"Environment=PULSE_SERVER=unix:/run/user/1000/pulse/native\n"
-	)
-endif()
-
-# Base service file bottom part.
-file(APPEND ${CMAKE_BINARY_DIR}/ledspicerd.service
 	"\n"
 	"[Install]\n"
 	"WantedBy=multi-user.target\n"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,14 +5,12 @@ project(LEDSpicer VERSION 0.7.6 LANGUAGES CXX)
 include(GNUInstallDirs)
 
 # Project details
-set(PROJECT_NAME      "${CMAKE_PROJECT_NAME}")
-set(PROJECT_VERSION   "${CMAKE_PROJECT_VERSION}")
-set(PROJECT_DATA_DIR  "${CMAKE_INSTALL_FULL_DATADIR}/ledspicer/")
-set(PROJECT_CONF_DIR  "${CMAKE_INSTALL_SYSCONFDIR}")
+set(PROJECT_NAME      ${CMAKE_PROJECT_NAME})
+set(PROJECT_VERSION   ${CMAKE_PROJECT_VERSION})
+set(PROJECT_DATA_DIR  ${CMAKE_INSTALL_FULL_DATADIR}/ledspicer/)
+set(PROJECT_CONF_DIR  ${CMAKE_INSTALL_SYSCONFDIR})
 set(PROJECT_SITE      "https://github.com/meduzapat/LEDSpicer")
 set(PROJECT_BUGREPORT "https://github.com/meduzapat/LEDSpicer/issues")
-set(COPYRIGHT         "Copyright © 2018 - 2026 Patricio A. Rossi")
-set(MAINTAINER_EMAIL  "meduzapat@netscape.net")
 set(DATA_VERSION      "1.1")
 
 # Set C++ standard
@@ -35,20 +33,11 @@ set(PKGCONFIG_DIR "${CMAKE_INSTALL_LIBDIR}/pkgconfig" CACHE PATH "pkg-config fil
 set(INSTALL_DOCDIR "${CMAKE_INSTALL_DATAROOTDIR}/doc/ledspicer" CACHE PATH "documentation and examples install directory")
 
 # Global compile definitions (for source code)
-add_compile_definitions(
-	PROJECT_NAME="${PROJECT_NAME}"
-	PROJECT_VERSION="${PROJECT_VERSION}"
-	PROJECT_DATA_DIR="${PROJECT_DATA_DIR}"
-	PROJECT_CONF_DIR="${PROJECT_CONF_DIR}"
-	PROJECT_SITE="${PROJECT_SITE}"
-	PROJECT_BUGREPORT="${PROJECT_BUGREPORT}"
-	COPYRIGHT="${COPYRIGHT}"
-	DATA_VERSION="${DATA_VERSION}"
-)
+configure_file(data/config.hpp.in ${CMAKE_SOURCE_DIR}/src/config.hpp @ONLY)
 
 # Options for conditional features
-option(ENABLE_PULSEAUDIO  "Enables the pulseaudio plugin"            ON)
-option(ENABLE_ALSAAUDIO   "Enables the alsaaudio plugin"             ON)
+option(ENABLE_PULSEAUDIO  "Enables the pulseaudio plugin"            OFF)
+option(ENABLE_ALSAAUDIO   "Enables the alsaaudio plugin"             OFF)
 # Devices
 option(ENABLE_NANOLED     "Enables the output plugin nanoled"        OFF)
 option(ENABLE_PACDRIVE    "Enables the output plugin pacdrive"       OFF)
@@ -275,7 +264,6 @@ endif()
 target_include_directories(ledspicerd PRIVATE ${LEDSPICER_INCLUDE_DIRS})
 target_link_libraries(ledspicerd ${LEDSPICER_LIBS})
 
-target_compile_definitions(ledspicerd PRIVATE DEVICES_DIR="${DEVICES_DIR}/")
 install(TARGETS ledspicerd RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 # Emitter utility

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 
-project(LEDSpicer VERSION 0.7.6 LANGUAGES CXX)
+project(LEDSpicer VERSION 0.7.7 LANGUAGES CXX)
 
 include(GNUInstallDirs)
 
@@ -11,6 +11,7 @@ set(PROJECT_DATA_DIR  ${CMAKE_INSTALL_FULL_DATADIR}/ledspicer/)
 set(PROJECT_CONF_DIR  ${CMAKE_INSTALL_SYSCONFDIR})
 set(PROJECT_SITE      "https://github.com/meduzapat/LEDSpicer")
 set(PROJECT_BUGREPORT "https://github.com/meduzapat/LEDSpicer/issues")
+set(MAINTAINER_EMAIL  "meduzapat@netscape.net")
 set(DATA_VERSION      "1.1")
 
 # Set C++ standard

--- a/data/config.hpp.in
+++ b/data/config.hpp.in
@@ -1,0 +1,41 @@
+/* -*- Mode: C; indent-tabs-mode: t; c-basic-offset: 4; tab-width: 4 -*-  */
+/**
+ * @file      config.cpp
+ * @since     Jun 29, 2026
+ * @author    Patricio A. Rossi (MeduZa)
+ *
+ * @copyright Copyright © 2018 - 2026 Patricio A. Rossi (MeduZa)
+ *
+ * @copyright LEDSpicer is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @copyright LEDSpicer is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * @copyright You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+namespace LEDSpicer {
+
+#define PROJECT_NAME     "@PROJECT_NAME@"
+#define PROJECT_VERSION  "@PROJECT_VERSION@"
+#define DATA_VERSION     "@DATA_VERSION@"
+#define PROJECT_DATA_DIR "@PROJECT_DATA_DIR@"
+#define PROJECT_CONF_DIR "@PROJECT_CONF_DIR@"
+#define DEVICES_DIR      "@DEVICES_DIR@"
+
+constexpr auto LICENSE_BLOCK =
+	PROJECT_NAME " " PROJECT_VERSION " Copyright © 2018 - 2026 Patricio A. Rossi\n\n"
+	"For more information visit <@PROJECT_SITE@>\n\n"
+	"To report errors or bugs visit <@PROJECT_SITE@/issues>\n"
+	PROJECT_NAME " is free software under the GPL 3 license\n\n"
+	"See the GNU General Public License for more details <http://www.gnu.org/licenses/>";
+
+}

--- a/data/config.hpp.in
+++ b/data/config.hpp.in
@@ -29,7 +29,7 @@ namespace LEDSpicer {
 #define DATA_VERSION     "@DATA_VERSION@"
 #define PROJECT_DATA_DIR "@PROJECT_DATA_DIR@"
 #define PROJECT_CONF_DIR "@PROJECT_CONF_DIR@"
-#define DEVICES_DIR      "@DEVICES_DIR@"
+#define DEVICES_DIR      "@DEVICES_DIR@" "/"
 
 constexpr auto LICENSE_BLOCK =
 	PROJECT_NAME " " PROJECT_VERSION " Copyright © 2018 - 2026 Patricio A. Rossi\n\n"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,10 +1,16 @@
-ledspicer (0.7.6-1) stable; urgency=medium
+ledspicer (0.7.7-1) stable; urgency=medium
 
+  * Added
+    - Automated release publishing to COPR and AUR.
+  * Changed
+    - Daemon starts independently of the user session and audio; audio now connects lazily so the service comes up as soon as the network is ready (#125)
+    - systemd service no longer waits on `sound.target` and no longer sets `PULSE_SERVER` — the daemon derives the per-user PulseAudio socket itself (#125)
+    - CMake build cleanups and definition fixes; generated `config.hpp`
   * Fixed
-    - Crash and cache handling for crafted profiles (#121)
-    - Use-after-free when loading same crafted profile twice
-    - Cache/retrieve crafted profiles by game name
-    - FORCE_RELOAD and REPLACE flags on craft/load path
-    - Profile stack history for FinishLastProfile
+    - ALSA capture device opens without throwing and reopens automatically if it is missing or later lost (#125)
+    - PulseAudio falls back to the background retry on an initial connection failure instead of aborting startup (#125)
+    - Rotator argument-parsing crash and a redundant initialization (#123)
+    - Non-working TOS serial restrictor (#123)
+    - Hardened `colorFormat` parsing (accepts `RGB`/`rgb`) and now warns on duplicate player/joystick rotator requests instead of silently dropping them (#123)
 
- -- Patricio A. Rossi <meduzapat@netscape.net>  Sun, 14 Jun 2026 00:57:18 -0400
+ -- Patricio A. Rossi (MeduZa) <meduzapat@netscape.net>  Mon, 29 Jun 2026 21:15:44 -0400

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -1,13 +1,35 @@
 # Development and Release Workflow
 
-## Repository Structure
+A personal maintainer runbook for developing, releasing, and packaging LEDSpicer.
+The publishing steps (PPA, AUR, COPR) rely on `meduzapat`'s own signing keys and
+accounts, so in practice only the maintainer can run them — this is a memo to
+self, not a contributor guide.
+
+- The **core guide** (sections 1–4) is the linear path: code → release → publish.
+- One-time machine/account setup lives in the
+  [Appendix: one-time setup](#appendix-one-time-setup). Core steps link to it where
+  needed, so you set it up once and skip it afterwards.
+- [Optional: test the packages](#optional-test-the-packages) is at the very end.
+
+`CMakeLists.txt` is the single source of truth — version, URL, maintainer, and
+email are read from it by `generate-changelogs.sh`. Never hardcode them elsewhere.
+
+**Conventions used below:** run commands from the project root (your local clone
+sitting on `development`). `BUILD_DIR` is wherever you build out-of-tree — set it
+once to suit your box, e.g. `BUILD_DIR=~/build/ledspicer`.
+
+> This document is the **manual fallback**. The goal is for tagging a release to
+> publish to AUR, Fedora (COPR) and Ubuntu (PPA) automatically; until that is in
+> place, or when something breaks, follow the steps here by hand.
+
+## 1. Repository structure
 
 ```
 LEDSpicer/
-├── CMakeLists.txt                ← Single source of truth (version, url, maintainer, email)
-├── CHANGELOG.md                  ← Changes in Keep a Changelog format
+├── CMakeLists.txt                ← single source of truth (version, url, maintainer, email)
+├── CHANGELOG.md                  ← changes in Keep a Changelog format
 ├── debian/
-│   ├── changelog                 ← Generated
+│   ├── changelog                 ← generated
 │   ├── control
 │   ├── rules
 │   ├── copyright
@@ -15,18 +37,21 @@ LEDSpicer/
 │   └── *.install
 └── packaging/
     ├── README.md                 ← this file
-    ├── generate-changelogs.sh
+    ├── generate-changelogs.sh    ← updates all distro files from CMakeLists.txt + CHANGELOG.md
     ├── arch/
-    │   ├── PKGBUILD              ← Updated by generate-changelogs.sh
+    │   ├── PKGBUILD              ← updated by generate-changelogs.sh (checksum stays SKIP, see 4.5)
+    │   ├── generate SRCINFO.sh   ← optional Docker helper to validate checksums/.SRCINFO
     │   ├── ledspicer.install
-    │   └── .SRCINFO              ← Generated (hidden file, do not forget)
+    │   └── .SRCINFO             ← generated (hidden file, do not forget to push to AUR)
     └── rpm/
-        └── ledspicer.spec        ← Updated by generate-changelogs.sh
+        └── ledspicer.spec        ← updated by generate-changelogs.sh
 ```
 
----
+Keeping the packaging metadata inside the code repo is intentional and required:
+Launchpad reads `debian/`, COPR reads `packaging/rpm/ledspicer.spec`, and the AUR
+`PKGBUILD` is sourced from `packaging/arch/`.
 
-## Branch Strategy
+## 2. Branch strategy
 
 ```
 master  ←  development  ←  feature branches
@@ -34,135 +59,356 @@ master  ←  development  ←  feature branches
 
 - `master` and `development` are protected — no direct pushes.
 - All changes go through pull requests on GitHub.
-- Any PR targeting `master` triggers the automated unit test suite.
+- A PR targeting `master` triggers the build and unit-test workflows.
+- `master` is effectively the release branch; a dedicated release branch is overkill.
 
----
+## 3. Development cycle
 
-## Development Cycle
+Repeat for each task or fix before a release.
 
-Repeat this cycle for each task or fix before a release.
-
-1. Pick a task or issue to work on.
-
-2. Create a feature branch off `development`:
+1. Create a feature branch off `development`:
    ```bash
    git checkout development
    git checkout -b feature/my-task
    ```
-
-3. Code the changes.
-
-4. Test manually.
-
-5. Run the automated test suite:
+2. Code the changes and test manually.
+3. Run the unit tests (no hardware needed, they use their own mocks). Tests are
+   gated by the `ENABLE_TESTS` option (default `OFF`); turning it on makes CMake
+   require GoogleTest and pull in `tests/CMakeLists.txt`, which builds everything
+   under `${BUILD_DIR}/tests`. `ENABLE_DRY_RUN` is unrelated (mock hardware for
+   the main binary) and not needed here.
    ```bash
-   cmake -S . -B build -DENABLE_TESTS=ON -DENABLE_DRY_RUN=ON
-   cmake --build build/tests -j$(nproc)
-   ctest --test-dir build/tests
+   cmake -S . -B "${BUILD_DIR}" -DENABLE_TESTS=ON
+   cd "${BUILD_DIR}/tests" && make && ctest
    ```
-
-6. Commit and push the branch:
+   Your IDE can do the same once configured with `-DENABLE_TESTS=ON`.
+4. Commit and push:
    ```bash
    git add -A
    git commit -m "Short description of change"
    git push origin feature/my-task
    ```
+5. Open a PR `feature/my-task` → `development` and merge once green.
 
-7. Open a pull request on GitHub: `feature/my-task` → `development` and merge it there.
+## 4. Release
 
-Repeat until the set of changes is ready to ship.
+Ground rules that explain the ordering:
 
----
+- The release **tag is created by the GitHub Release**, after `development` is
+  merged into `master`. So everything that must live inside the tag — the Fedora
+  `.spec` and the Debian `changelog` — has to be committed on `development`
+  *before* the PR (step 4.1), so it travels into `master` and into the tag.
+- After the tag exists, **nothing goes back into the code repo.** The only
+  post-tag value is the Arch checksum, which lives solely in the separate AUR
+  repo (see 4.5).
 
-## Release
+> **If you spot something off mid-release** (missing code, wrong changelog, a
+> packaging fix) after the Release/tag is cut: delete the GitHub Release **and**
+> delete the tag, go back to `development`, fix it, and start over from 4.1. Do
+> not patch on top of a published tag — re-cut it. (`git push --delete origin
+> <tag>` removes the tag once the Release is deleted in the UI.)
 
-### 1. Prepare
+### 4.0 Set release variables
 
-1. Update the version in `CMakeLists.txt`:
+Sit in the project root on `development`. `VERSION` is read from `CMakeLists.txt`,
+so nothing is hardcoded:
+
+```bash
+AUR_DIR=~/aur/ledspicer        # local clone of the AUR repo (see appendix)
+RPMBUILD=~/rpmbuild            # only needed for the manual COPR fallback
+```
+
+### 4.1 Prepare on `development`
+
+1. Bump the version in `CMakeLists.txt` (and `DATA_VERSION` if the data format
+   changed):
    ```
    project(LEDSpicer VERSION x.y.z ...)
    ```
+2. Add a new section to `CHANGELOG.md` (Keep a Changelog format). To draft it,
+   feed this prompt to an AI with access to the repo history (Copilot, Claude, …):
 
-2. Add a new section to `CHANGELOG.md` summarising all changes since the last release.
+   > Prepare the CHANGELOG.md entry for LEDSpicer vX.Y.Z. Review everything merged
+   > into `development` since tag `<previous>`. Output only a "Keep a Changelog"
+   > section starting with `## [X.Y.Z] - YYYY-MM-DD`, using only the subsections
+   > that have content (Added, Changed, Fixed, Removed, Breaking Changes). One
+   > concise line per bullet, user-facing impact, cite issue/PR numbers in
+   > parentheses when known. No marketing, no duplicates, no fluff.
 
-3. Run the changelog generator:
+3. Re-read the version now that you changed it:
+   ```bash
+   VERSION=$(sed -n 's/.*project(LEDSpicer VERSION \([0-9.]*\).*/\1/p' CMakeLists.txt)
+   echo "Releasing $VERSION"
+   ```
+4. Run the generator. The tag does not exist yet, so the Arch checksum falls back
+   to `SKIP` — that is expected and stays that way in the repo (fixed at AUR
+   publish time in 4.5):
    ```bash
    ./packaging/generate-changelogs.sh
    ```
-   This updates:
-   - `debian/changelog`
-   - `packaging/arch/PKGBUILD` (version + checksum)
-   - `packaging/arch/.SRCINFO`
-   - `packaging/rpm/ledspicer.spec` (version + changelog entry)
-
-4. Review the generated files, then commit, tag, and push:
+   It updates `debian/changelog`, `packaging/rpm/ledspicer.spec`,
+   `packaging/arch/PKGBUILD` (version), and `packaging/arch/.SRCINFO`.
+5. Review the generated files, then commit and push:
    ```bash
    git add -A
-   git commit -m "Release x.y.z"
-   git tag x.y.z
-   git push
-   git push --tags
+   git commit -m "Release ${VERSION}"
+   git push origin development
    ```
 
-5. Open a pull request on GitHub: `development` → `master`. This triggers the automated unit
-   test suite — merge only after it passes.
+### 4.2 PR to `master`
 
-### 2. PPA (Ubuntu / Debian)
+Open a PR `development` → `master`. This runs the build and unit-test workflows.
+Merge only after they pass; a short "release candidate" merge message is fine.
+The spec and debian changelog are now in `master`.
 
-**Option A — Launchpad git remote** (triggers build automatically):
+### 4.3 Cut the GitHub Release
+
+On GitHub, switch to `master` and create the Release. This is what **creates the
+`${VERSION}` tag** and publishes the source tarball.
+
+For a polished release description, feed this prompt to an AI with the changelog
+section:
+
+> Write a concise GitHub Release description for LEDSpicer vX.Y.Z based strictly
+> on this changelog section: `<paste>`. Open with one sentence on the release's
+> theme, then short grouped highlights (Highlights / Fixes / Breaking) only where
+> there is content. Under ~150 words. No install instructions, no hyperbole. End
+> with a link to the full changelog.
+
+### 4.4 Publish — PPA (Ubuntu / Debian)
+
+First time? See [PPA / Launchpad setup](#ppa--launchpad-setup).
+
 ```bash
 git push launchpad master
 ```
 
-**Option B — dput**:
+The Launchpad recipe does **not** build on push automatically. Either enable
+"Build daily" on the recipe, or open the recipe page and click **Request
+build(s)** to build now. Monitor at
+https://launchpad.net/~meduzapat/+archive/ubuntu/ledspicer
+
+### 4.5 Publish — AUR (Arch Linux)
+
+First time? See [AUR setup](#aur-setup).
+
+Now that the tag tarball exists, fill in the real Arch checksum, push it to the
+**AUR repo only**, then discard the local change so the code repo keeps `SKIP`:
+
 ```bash
-dput ppa:meduzapat/ledspicer ../ledspicer_VERSION_source.changes
+./packaging/generate-changelogs.sh                 # now fetches the real sha256
+cp packaging/arch/PKGBUILD  "${AUR_DIR}/"
+cp packaging/arch/.SRCINFO "${AUR_DIR}/"
+git -C "${AUR_DIR}" add PKGBUILD .SRCINFO
+git -C "${AUR_DIR}" commit -m "Update to ${VERSION}"
+git -C "${AUR_DIR}" push
+git restore packaging/arch/PKGBUILD packaging/arch/.SRCINFO   # keep the code repo at SKIP
 ```
 
-Monitor at https://launchpad.net/~meduzapat/+archive/ubuntu/ledspicer
+> Why the checksum never lives in the code repo: the tarball it hashes *contains*
+> `PKGBUILD`, so writing the hash into `PKGBUILD` would change the tarball and
+> invalidate the hash. It is only meaningful in the AUR repo. If it still prints
+> `SKIP`, GitHub has not finished publishing the tag tarball — wait a minute and
+> re-run. Verify at https://aur.archlinux.org/packages/ledspicer
 
-### 3. AUR (Arch Linux)
+### 4.6 Publish — COPR (Fedora / RPM)
 
-The generator already updated `PKGBUILD` and `.SRCINFO` — both must be pushed.
+**Primary — build from the repo automatically.** Once COPR is configured to build
+from the Git source (one-time, see [COPR setup](#copr-setup)), cutting the Release
+in 4.3 is all that is needed: the webhook makes COPR clone the tag, find
+`packaging/rpm/ledspicer.spec`, and build. Nothing to do here. Monitor at
+https://copr.fedorainfracloud.org/coprs/meduzapat/ledspicer/
 
-First-time clone:
+<details>
+<summary>Fallback — build and upload an SRPM by hand</summary>
+
+Use this only if COPR auto-build is not set up, or it failed. Needs a Fedora
+machine (or container). First time? See [Fedora build tree](#fedora-build-tree)
+and [COPR setup](#copr-setup).
+
+```bash
+rm -f "${RPMBUILD}/SOURCES/"*
+cp packaging/rpm/ledspicer.spec "${RPMBUILD}/SPECS/"
+git archive --format=tar.gz --prefix="LEDSpicer-${VERSION}/" "${VERSION}" \
+    > "${RPMBUILD}/SOURCES/LEDSpicer-${VERSION}.tar.gz"
+rpmbuild -bs "${RPMBUILD}/SPECS/ledspicer.spec"
+copr-cli build meduzapat/ledspicer "${RPMBUILD}/SRPMS/ledspicer-${VERSION}"*.src.rpm
+```
+
+Archiving from the `${VERSION}` tag (not `HEAD`) guarantees the SRPM matches the
+released tarball. You can also upload the `.src.rpm` via the COPR web UI.
+</details>
+
+---
+
+## 5. Automation (the happy path)
+
+Once the setup below is in place, **cutting the GitHub Release (4.3) is the only
+manual trigger** — `.github/workflows/release.yml` and Launchpad's daily build do
+the rest. The step-by-step publish actions in [section 4](#4-release) become the
+**fallback** for when automation is off or a build breaks.
+
+What happens when you publish a Release:
+
+| Target | Trigger | Mechanism |
+|---|---|---|
+| **AUR** | `release: published` | `release.yml` regenerates `PKGBUILD`/`.SRCINFO` with the real checksum and pushes to the AUR repo over SSH |
+| **Fedora / COPR** | `release: published` | `release.yml` POSTs to COPR's custom webhook; COPR rebuilds from the tag |
+| **Ubuntu / PPA** | within ~24h | Launchpad recipe "Build daily" — **after** you `git push launchpad master` (still manual until an optional GitHub→Launchpad code import is set up) |
+
+The workflow fires on `release: published` on purpose: only then do the tag and
+its source tarball exist, which both the AUR checksum and the Fedora `Source0`
+depend on. AUR and COPR run as independent jobs, so one distro failing never
+blocks the other.
+
+**Required GitHub Actions secrets** (repo → Settings → Secrets → Actions):
+
+| Secret | What it is | Blast radius |
+|---|---|---|
+| `AUR_SSH_PRIVATE_KEY` | private half of a **dedicated CI** SSH key registered on the AUR account | revoke just that key if leaked; main AUR key untouched |
+| `COPR_WEBHOOK_URL` | the full COPR **custom** webhook URL for the `ledspicer` package | package-scoped — can only trigger a build of this one package |
+
+PPA still needs no GitHub secret: Launchpad builds and signs with the GPG key held
+on its own side.
+
+---
+
+
+Per-machine / per-account setup. Do it once, then ignore it on later releases.
+Accounts stay under the personal `meduzapat` namespace across all platforms.
+
+### Build dependencies
+
+Needed to compile and run the unit tests locally.
+
+```bash
+# Debian / Ubuntu
+sudo apt-get install build-essential cmake pkg-config \
+    libtinyxml2-dev libpulse-dev libasound2-dev libusb-1.0-0-dev libgtest-dev
+
+# Fedora
+sudo dnf install gcc-c++ cmake pkgconf tinyxml2-devel \
+    pulseaudio-libs-devel alsa-lib-devel libusb1-devel gtest-devel
+
+# Arch
+sudo pacman -S --needed base-devel cmake pkgconf tinyxml2 libpulse alsa-lib libusb gtest
+```
+
+### COPR setup
+
+**SCM auto-build (recommended).** In the COPR web UI, open project
+`meduzapat/ledspicer` → Packages → New package → SCM:
+
+- Clone URL: `https://github.com/meduzapat/LEDSpicer.git`
+- Committish: `master`
+- Spec file: `packaging/rpm/ledspicer.spec`
+- SRPM build method: **`rpkg`**
+- Enable "auto-rebuild from webhook"
+
+Use `rpkg` (not `make_srpm`) because the spec is a plain spec whose `Source0`
+already points at the released tag tarball — `rpkg` just downloads that exact
+tarball and builds, with no `.copr/Makefile` to maintain and the same tarball AUR
+and the manual flow use. `make_srpm` would only be needed to build untagged
+snapshots from the git tree.
+
+**Triggering.** Do **not** register COPR's URL as a GitHub *push* webhook — that
+fires on the `development → master` merge, before the tag tarball exists, and
+404s. Instead, grab the **custom** webhook URL (Settings → Integrations → the
+`/webhooks/custom/...` one, *not* `/webhooks/github/...` or `/webhooks/custom-dir/...`),
+store it in the `COPR_WEBHOOK_URL` secret, and let
+[`release.yml`](#5-automation-the-happy-path) POST to it after the Release is cut.
+
+**copr-cli (only for the manual fallback).**
+
+```bash
+sudo dnf install copr-cli
+```
+
+Place your API token in `~/.config/copr` — generate it at
+https://copr.fedorainfracloud.org/api/
+
+### Fedora build tree
+
+Only needed for the manual COPR fallback, on a Fedora machine. `rpmbuild` expects
+`~/rpmbuild/{BUILD,RPMS,SOURCES,SPECS,SRPMS}` to exist; it is not created
+automatically:
+
+```bash
+sudo dnf install rpmdevtools
+rpmdev-setuptree
+```
+
+### PPA / Launchpad setup
+
+Add the Launchpad git remote to your local clone (same working dir you release
+from):
+
+```bash
+git remote add launchpad git+ssh://<your-lp-user>@git.launchpad.net/ledspicer
+```
+
+Create a source-package **recipe** on Launchpad pointing at `master`. Note that
+recipes do not build on push — enable "Build daily", or click "Request build(s)"
+after pushing. Building requires your GPG signing key registered with Launchpad.
+
+### AUR setup
+
+For the **manual** flow, upload your personal SSH public key to your AUR account
+and clone the package repo once:
+
 ```bash
 git clone ssh://aur@aur.archlinux.org/ledspicer.git ~/aur/ledspicer
 ```
 
-Copy and push:
-```bash
-cd ~/aur/ledspicer
-cp /path/to/LEDSpicer/packaging/arch/PKGBUILD .
-cp /path/to/LEDSpicer/packaging/arch/.SRCINFO .
-git add PKGBUILD .SRCINFO
-git commit -m "Update to x.y.z"
-git push
-```
+This is the `AUR_DIR` used in [4.5](#45-publish--aur-arch-linux).
 
-Verify at https://aur.archlinux.org/packages/ledspicer
-
-### 4. COPR (Fedora / RPM)
-
-The generator already updated `packaging/rpm/ledspicer.spec`. Build the SRPM:
+For the **automated** flow, generate a **dedicated CI keypair** (don't reuse your
+personal key), register its public half on the AUR account, and put the private
+half in the `AUR_SSH_PRIVATE_KEY` secret. A separate key means a leak is contained
+to CI — revoke it on AUR without touching your own key:
 
 ```bash
-VERSION=x.y.z
-rm ~/rpmbuild/SOURCES/*
-cp packaging/rpm/ledspicer.spec ~/rpmbuild/SPECS/
-git archive --format=tar.gz --prefix=LEDSpicer-${VERSION}/ HEAD \
-    > ~/rpmbuild/SOURCES/LEDSpicer-${VERSION}.tar.gz
-rpmbuild -bs ~/rpmbuild/SPECS/ledspicer.spec
+ssh-keygen -t ed25519 -f aur-ci -C "ledspicer-ci" -N ""
+# add aur-ci.pub to https://aur.archlinux.org/account → SSH Public Key (one per line)
+# paste the contents of aur-ci (private) into the GitHub secret AUR_SSH_PRIVATE_KEY
 ```
 
-This produces `~/rpmbuild/SRPMS/ledspicer-VERSION*.src.rpm`. Submit it with either:
+---
 
-**Option A — Web UI**: go to https://copr.fedorainfracloud.org/coprs/meduzapat/ledspicer/ →
-New Build → Upload SRPM.
+## Optional: test the packages
 
-**Option B — copr-cli**:
+Before releasing, you can confirm each package builds cleanly. None of this is
+required, but it catches packaging mistakes early.
+
+**Unit tests (all platforms).** Same as the development cycle:
+
 ```bash
-copr-cli build meduzapat/ledspicer ~/rpmbuild/SRPMS/ledspicer-VERSION*.src.rpm
+cmake -S . -B "${BUILD_DIR}" -DENABLE_TESTS=ON
+cd "${BUILD_DIR}/tests" && make && ctest
 ```
-Requires one-time setup: install `copr-cli` and place your API token in `~/.config/copr`
-(available at https://copr.fedorainfracloud.org/api/).
+
+**Arch — validate checksums and `.SRCINFO`.** The Docker helper builds in a clean
+Arch container and prints the generated checksums and `.SRCINFO` without touching
+your system:
+
+```bash
+cd packaging/arch
+./"generate SRCINFO.sh"
+```
+
+For a full build, run `makepkg -si` from `packaging/arch` (ideally in a clean
+chroot via `extra-x86_64-build`).
+
+**Fedora — local build and lint** (on a Fedora machine):
+
+```bash
+rpmbuild -bb "${RPMBUILD}/SPECS/ledspicer.spec"   # full build
+rpmlint  "${RPMBUILD}/SPECS/ledspicer.spec"       # spec sanity check
+mock -r fedora-rawhide-x86_64 "${RPMBUILD}/SRPMS/ledspicer-${VERSION}"*.src.rpm
+```
+
+**Debian — local build:**
+
+```bash
+debuild -us -uc          # from the repo root, unsigned build
+```

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -15,7 +15,7 @@ pkgname=(
 	'ledspicer-dev'
 )
 
-pkgver=0.7.6
+pkgver=0.7.7
 pkgrel=1
 pkgdesc="LED controller daemon for arcade cabinets and RGB lighting"
 arch=('x86_64' 'aarch64' 'armv7h')

--- a/packaging/generate-changelogs.sh
+++ b/packaging/generate-changelogs.sh
@@ -26,7 +26,6 @@ VERSION=$(sed -n 's/.*project(LEDSpicer VERSION \([0-9.]*\).*/\1/p' "$CMAKE_FILE
 DATA_VERSION=$(sed -n 's/.*set(DATA_VERSION[[:space:]]*"\([0-9.]*\)".*/\1/p' "$CMAKE_FILE")
 URL=$(sed -n 's/.*set(PROJECT_SITE[[:space:]]*"\([^"]*\)".*/\1/p' "$CMAKE_FILE")
 EMAIL=$(sed -n 's/.*set(MAINTAINER_EMAIL[[:space:]]*"\([^"]*\)".*/\1/p' "$CMAKE_FILE")
-# Extract maintainer name from COPYRIGHT line: "Copyright © 2018 - 2026 Patricio A. Rossi"
 MAINTAINER=$(sed -n 's/.*set(COPYRIGHT[[:space:]]*"[^"]*[0-9]\{4\} \(.*\)").*/\1/p' "$CMAKE_FILE")
 
 # Validate required values

--- a/packaging/rpm/ledspicer.spec
+++ b/packaging/rpm/ledspicer.spec
@@ -5,7 +5,7 @@
 %global debug_package %{nil}
 
 Name:           ledspicer
-Version:        0.7.6
+Version:        0.7.7
 Release:        1%{?dist}
 Summary:        LED controller daemon for arcade cabinets and RGB lighting
 License:        GPL-3.0-or-later
@@ -196,10 +196,16 @@ that use the LEDSpicer library.
 # =============================================================================
 
 %changelog
-* Sun Jun 14 2026 Patricio A. Rossi <meduzapat@netscape.net> - 0.7.6-1
+* Mon Jun 29 2026 Patricio A. Rossi (MeduZa) <meduzapat@netscape.net> - 0.7.7-1
+- Added
+  - Automated release publishing to COPR and AUR.
+- Changed
+  - Daemon starts independently of the user session and audio; audio now connects lazily so the service comes up as soon as the network is ready (#125)
+  - systemd service no longer waits on `sound.target` and no longer sets `PULSE_SERVER` — the daemon derives the per-user PulseAudio socket itself (#125)
+  - CMake build cleanups and definition fixes; generated `config.hpp`
 - Fixed
-  - Crash and cache handling for crafted profiles (#121)
-  - Use-after-free when loading same crafted profile twice
-  - Cache/retrieve crafted profiles by game name
-  - FORCE_RELOAD and REPLACE flags on craft/load path
-  - Profile stack history for FinishLastProfile
+  - ALSA capture device opens without throwing and reopens automatically if it is missing or later lost (#125)
+  - PulseAudio falls back to the background retry on an initial connection failure instead of aborting startup (#125)
+  - Rotator argument-parsing crash and a redundant initialization (#123)
+  - Non-working TOS serial restrictor (#123)
+  - Hardened `colorFormat` parsing (accepts `RGB`/`rgb`) and now warns on duplicate player/joystick rotator requests instead of silently dropping them (#123)

--- a/src/DataLoader.cpp
+++ b/src/DataLoader.cpp
@@ -141,6 +141,43 @@ void DataLoader::processDevices() {
 	}
 }
 
+void DataLoader::parseColorOrder(
+	const string& colorFormat,
+	uint16_t& c,
+	uint16_t& r,
+	uint16_t& g,
+	uint16_t& b,
+	vector<bool>& ledCheck,
+	const string& location
+) {
+	// Must be a permutation of the three channels, one each, case insensitive.
+	if (colorFormat.size() != 3
+		or colorFormat.find_first_not_of("RGBrgb") != string::npos
+		or colorFormat.find_first_of("Rr") == string::npos
+		or colorFormat.find_first_of("Gg") == string::npos
+		or colorFormat.find_first_of("Bb") == string::npos)
+		throw Utilities::Error("Color format must be a permutation of R, G and B, got '" + colorFormat + "' in " + location);
+	for (char col : colorFormat) {
+		switch (col) {
+		case 'R':
+		case 'r':
+			ledCheck[c] = true;
+			r = c++;
+			break;
+		case 'G':
+		case 'g':
+			ledCheck[c] = true;
+			g = c++;
+			break;
+		case 'B':
+		case 'b':
+			ledCheck[c] = true;
+			b = c++;
+			break;
+		}
+	}
+}
+
 void DataLoader::processDeviceElements(tinyxml2::XMLElement* deviceNode, Device* device) {
 
 	// Only used to report unused LEDs.
@@ -207,8 +244,8 @@ void DataLoader::processDeviceElements(tinyxml2::XMLElement* deviceNode, Device*
 				// 1st RGB element
 				pos  ((Utility::parseNumber(tempAttr[PARAM_POSITION], invalidValueFor(PARAM_POSITION) " in " + device->getFullName()) - 1) * 3),
 				elem (1);
-			string
-				order(tempAttr.exists(PARAM_COLORFORMAT) ? tempAttr.at(PARAM_COLORFORMAT) : DEFAULT_ORDER),
+			const string
+				rgbFormat(tempAttr.exists(PARAM_COLORFORMAT) ? tempAttr.at(PARAM_COLORFORMAT) : DEFAULT_ORDER),
 				groupName(name);
 			// Create a group for the strip only.
 			if (size > 3)
@@ -222,22 +259,7 @@ void DataLoader::processDeviceElements(tinyxml2::XMLElement* deviceNode, Device*
 			// Process element(s)
 			for (uint16_t c = pos; c < pos + size; ++elem) {
 				string elemName(name + (size > 3 ? to_string(elem) : ""));
-				for (char col : order) {
-					switch (col) {
-					case 'r':
-						ledCheck[c] = true;
-						r = c++;
-						break;
-					case 'g':
-						ledCheck[c] = true;
-						g = c++;
-					break;
-					case 'b':
-						ledCheck[c] = true;
-						b = c++;
-					break;
-					}
-				}
+				parseColorOrder(rgbFormat, c, r, g, b, ledCheck, device->getFullName());
 				device->registerElement(
 					elemName,
 					r, g , b,
@@ -265,23 +287,7 @@ void DataLoader::processDeviceElements(tinyxml2::XMLElement* deviceNode, Device*
 				if (not Utility::verifyValue<uint16_t>(pos, 0, device->getNumberOfElements())) {
 					throw Utilities::Error("Invalid value " + posStr + " in " + tempAttr.at(PARAM_POSITIONS) + " for element " + name + " in " + device->getFullName());
 				}
-				// Process element(s)
-				for (char col : order) {
-					switch (col) {
-					case 'r':
-						ledCheck[c] = true;
-						r = c++;
-						break;
-					case 'g':
-						ledCheck[c] = true;
-						g = c++;
-					break;
-					case 'b':
-						ledCheck[c] = true;
-						b = c++;
-					break;
-					}
-				}
+				parseColorOrder(order, c, r, g, b, ledCheck, name + " in " + device->getFullName());
 				ledPositions.push_back(r);
 				ledPositions.push_back(g);
 				ledPositions.push_back(b);

--- a/src/DataLoader.hpp
+++ b/src/DataLoader.hpp
@@ -301,6 +301,28 @@ protected:
 	void processDeviceElements(tinyxml2::XMLElement* deviceNode, Device* device);
 
 	/**
+	 * Resolves a colorFormat order (a permutation of R, G and B, case
+	 * insensitive) into the three channel LED indices, advancing the running
+	 * index and marking every consumed LED.
+	 * @param colorFormat the channel order, e.g. "RGB" or "grb"
+	 * @param c running LED index, advanced by 3
+	 * @param r set to the red channel LED index
+	 * @param g set to the green channel LED index
+	 * @param b set to the blue channel LED index
+	 * @param ledCheck per LED used flags, marked for each channel
+	 * @param location context appended to error messages
+	 */
+	static void parseColorOrder(
+		const string& colorFormat,
+		uint16_t& c,
+		uint16_t& r,
+		uint16_t& g,
+		uint16_t& b,
+		vector<bool>& ledCheck,
+		const string& location
+	);
+
+	/**
 	 * Reads the layout and group sections from config.
 	 * @return the default layout properties.
 	 */

--- a/src/Defaults.hpp
+++ b/src/Defaults.hpp
@@ -80,6 +80,8 @@ using std::chrono::duration_cast;
 #include <thread>
 using std::this_thread::sleep_for;
 
+#include "config.hpp"
+
 #pragma once
 
 template<

--- a/src/Emitter.cpp
+++ b/src/Emitter.cpp
@@ -95,15 +95,7 @@ int main(int argc, char **argv) {
 
 		// Version Text.
 		if (commandline == "-v" or commandline == "--version") {
-			cout
-				<< endl <<
-				"Emitter is part of " PROJECT_NAME PROJECT_VERSION << endl <<
-				PROJECT_NAME PROJECT_VERSION " " COPYRIGHT "\n\n"
-				"For more information visit <" PROJECT_SITE ">\n\n"
-				"To report errors or bugs visit <" PROJECT_BUGREPORT ">\n"
-				PROJECT_NAME " is free software under the GPL 3 license\n\n"
-				"See the GNU General Public License for more details <http://www.gnu.org/licenses/>"
-				<< endl;
+			cout << endl << "Emitter is part of " << LEDSpicer::LICENSE_BLOCK << endl;
 			return EXIT_SUCCESS;
 		}
 

--- a/src/InputSeeker.cpp
+++ b/src/InputSeeker.cpp
@@ -30,16 +30,8 @@ void resetInputMode() {
 }
 
 int main(int, char **) {
-
-	cout <<
-		"Input Seeker v" PROJECT_VERSION << endl <<
-		"Part of LEDSpicer project" << endl <<
-		"This program will open all the system inputs and listen for events to easy the task of setting input plugins" << endl << endl <<
-		PROJECT_NAME PROJECT_VERSION " " COPYRIGHT "\n\n"
-		"For more information visit <" PROJECT_SITE ">\n\n"
-		"To report errors or bugs visit <" PROJECT_BUGREPORT ">\n"
-		PROJECT_NAME " is free software under the GPL 3 license\n\n"
-		"See the GNU General Public License for more details <http://www.gnu.org/licenses/>" << endl << endl <<
+	cout << endl <<
+		"Input Seeker is part of " << LICENSE_BLOCK << endl <<
 		"press q to exit" << endl << endl;
 
 	DIR *dir;

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -307,14 +307,7 @@ int main(int argc, char **argv) {
 
 		// Version Text.
 		if (commandline == "-v" or commandline == "--version") {
-			cout
-				<< endl <<
-				PROJECT_NAME " " PROJECT_VERSION " " COPYRIGHT "\n\n"
-				"For more information visit <" PROJECT_SITE ">\n\n"
-				"To report errors or bugs visit <" PROJECT_BUGREPORT ">\n"
-				PROJECT_NAME " is free software under the GPL 3 license\n\n"
-				"See the GNU General Public License for more details <http://www.gnu.org/licenses/>"
-				<< endl;
+			cout << endl << LICENSE_BLOCK << endl;
 			return EXIT_SUCCESS;
 		}
 

--- a/src/ProcessLookup.cpp
+++ b/src/ProcessLookup.cpp
@@ -294,15 +294,7 @@ int main(int argc, char **argv) {
 
 		// Version Text.
 		if (commandline == "-v" or commandline == "--version") {
-			cout
-				<< endl <<
-				"processLookup is part of " PROJECT_NAME PROJECT_VERSION << endl <<
-				PROJECT_NAME PROJECT_VERSION " " COPYRIGHT "\n\n"
-				"For more information visit <" PROJECT_SITE ">\n\n"
-				"To report errors or bugs visit <" PROJECT_BUGREPORT ">\n"
-				PROJECT_NAME " is free software under the GPL 3 license\n\n"
-				"See the GNU General Public License for more details <http://www.gnu.org/licenses/>"
-				<< endl;
+			cout << endl << "processLookup is part of " << LICENSE_BLOCK << endl;
 			return EXIT_SUCCESS;
 		}
 

--- a/src/Rotator.cpp
+++ b/src/Rotator.cpp
@@ -97,21 +97,31 @@ int main(int argc, char **argv) {
 
 		// Reset Only.
 		if (commandline == "-r" or commandline == "--reset") {
+			if (i + 1 >= argc) {
+				LogError("Missing value for " + commandline);
+				return EXIT_FAILURE;
+			}
 			resetWays = argv[++i];
 			continue;
 		}
 
 		// Alternative configuration.
 		if (commandline == "-c" or commandline == "--config") {
+			if (i + 1 >= argc) {
+				LogError("Missing value for " + commandline);
+				return EXIT_FAILURE;
+			}
 			configFile = argv[++i];
 			continue;
 		}
 
-		if ((i + 2) > argc) {
+		if ((i + 2) >= argc) {
 			LogError("Invalid player data");
 			return EXIT_FAILURE;
 		}
-		playersRequestedData.emplace(commandline + "_" + argv[i + 1], Restrictor::str2ways(argv[i + 2]));
+		const string key(commandline + "_" + argv[i + 1]);
+		if (not playersRequestedData.emplace(key, Restrictor::str2ways(argv[i + 2])).second)
+			LogWarning("Duplicate request for " + Restrictor::getProfileStr(key) + ", ignoring the second value");
 		i+=2;
 	}
 
@@ -119,8 +129,6 @@ int main(int argc, char **argv) {
 		LogError("Nothing to do");
 		return EXIT_SUCCESS;
 	}
-
-	Log::initialize(true);
 
 	if (configFile.empty())
 		configFile = CONFIG_FILE;
@@ -179,6 +187,7 @@ int main(int argc, char **argv) {
 				// Set Rotations.
 				if (playersRequestedData.size() and playersRequestedData.exists(pd.first)) {
 					availablePlayersData.emplace(pd.first, playersRequestedData.at(pd.first));
+					playersRequestedData.erase(pd.first);
 				}
 				// Reset all.
 				else if (resetWays.size()) {
@@ -199,7 +208,9 @@ int main(int argc, char **argv) {
 			delete restrictor;
 			sleep_for(std::chrono::milliseconds(250));
 		}
-
+		// Anything left was requested but matched no restrictor.
+		for (const auto& pd : playersRequestedData)
+			LogWarning(Restrictor::getProfileStr(pd.first) + " requested but not found in any restrictor");
 	}
 	catch(Error& e) {
 		LogError("Error: " + e.getMessage());

--- a/src/Rotator.cpp
+++ b/src/Rotator.cpp
@@ -83,15 +83,7 @@ int main(int argc, char **argv) {
 
 		// Version Text.
 		if (commandline == "-v" or commandline == "--version") {
-			cout
-				<< endl <<
-				"Rotator is part of " PROJECT_NAME PROJECT_VERSION << endl <<
-				PROJECT_NAME PROJECT_VERSION " " COPYRIGHT "\n\n"
-				"For more information visit <" PROJECT_SITE ">\n\n"
-				"To report errors or bugs visit <" PROJECT_BUGREPORT ">\n"
-				PROJECT_NAME " is free software under the GPL 3 license\n\n"
-				"See the GNU General Public License for more details <http://www.gnu.org/licenses/>"
-				<< endl;
+			cout << endl << "Rotator is part of " << LEDSpicer::LICENSE_BLOCK << endl;
 			return EXIT_SUCCESS;
 		}
 

--- a/src/animations/AlsaAudio.cpp
+++ b/src/animations/AlsaAudio.cpp
@@ -26,35 +26,41 @@ using namespace LEDSpicer::Animations;
 
 using LEDSpicer::Devices::Group;
 
-snd_pcm_t* AlsaAudio::pcm    = nullptr;
+snd_pcm_t* AlsaAudio::pcm     = nullptr;
 uint8_t AlsaAudio::instances = 0;
+string AlsaAudio::pcmName;
 
 AlsaAudio::AlsaAudio(StringUMap& parameters, Group* const group) :
 	AudioActor(parameters, group) {
 
 	++instances;
+	if (pcm) return;
 
-	LogInfo("Connecting to ALSA " SND_LIB_VERSION_STR);
+	if (pcmName.empty())
+		pcmName = parameters.exists("pcm") ? parameters["pcm"] : "default";
 
-	if (pcm) {
-		LogInfo("Reusing ALSA connection");
-		return;
-	}
+	// Does not throw: calcPeak retries if the device is not ready or later drops.
+	connect();
+}
 
-	string PCM = parameters.exists("pcm") ? parameters["pcm"] : "default";
+AlsaAudio::~AlsaAudio() {
+	if (--instances) return;
+	disconnect();
+}
+
+bool AlsaAudio::connect() {
 
 	int err;
-	// Open with non-blocking flag
-	if ((err = snd_pcm_open(&pcm, PCM.c_str(), SND_PCM_STREAM_CAPTURE, SND_PCM_NONBLOCK)) < 0)
-		throw Error("Unable to open ") << PCM << ": " << snd_strerror(err);
+	// Non-blocking so a missing device fails fast.
+	if ((err = snd_pcm_open(&pcm, pcmName.c_str(), SND_PCM_STREAM_CAPTURE, SND_PCM_NONBLOCK)) < 0) {
+		LogDebug("Unable to open " + pcmName + ": " + snd_strerror(err));
+		pcm = nullptr;
+		return false;
+	}
 
-	// Calculate latency based on FPS
-	// Frame time = 1000ms / FPS
-	uint32_t frameTimeMs = 1000 / getFPS();
-	// Buffer should be 2-3x frame time to prevent underruns
-	uint32_t bufferLatencyUs = frameTimeMs * 2500;
+	// Buffer should be 2-3x the frame time to prevent underruns.
+	uint32_t bufferLatencyUs = (1000 / getFPS()) * 2500;
 
-	// Set basic parameters with appropriate latency
 	if ((err = snd_pcm_set_params(
 		pcm,
 		SND_PCM_FORMAT_S16_LE,
@@ -63,30 +69,40 @@ AlsaAudio::AlsaAudio(StringUMap& parameters, Group* const group) :
 		SAMPLE_RATE,
 		0,  // No resampling
 		bufferLatencyUs
-	)) < 0)
-		throw Error("Unable to set parameters for " + PCM + ": " + string(snd_strerror(err)));
-	// Explicitly prepare the PCM
-	if ((err = snd_pcm_prepare(pcm)) < 0)
-		throw Error("Unable to prepare PCM: " + string(snd_strerror(err)));
+	)) < 0) {
+		LogDebug("Unable to set parameters for " + pcmName + ": " + string(snd_strerror(err)));
+		disconnect();
+		return false;
+	}
 
-	// Start capture
-	if ((err = snd_pcm_start(pcm)) < 0)
-		throw Error("Unable to start PCM: " + string(snd_strerror(err)));
+	if ((err = snd_pcm_prepare(pcm)) < 0) {
+		LogDebug("Unable to prepare PCM: " + string(snd_strerror(err)));
+		disconnect();
+		return false;
+	}
 
-	LogInfo("ALSA connected");
+	if ((err = snd_pcm_start(pcm)) < 0) {
+		LogDebug("Unable to start PCM: " + string(snd_strerror(err)));
+		disconnect();
+		return false;
+	}
+
+	LogInfo("ALSA connected to " + pcmName);
+	return true;
 }
 
-AlsaAudio::~AlsaAudio() {
-	--instances;
-	if (instances > 0) return;
-
-	LogInfo("Closing ALSA");
+void AlsaAudio::disconnect() {
+	if (not pcm) return;
 	snd_pcm_drop(pcm);
 	snd_pcm_close(pcm);
 	pcm = nullptr;
 }
 
 void AlsaAudio::calcPeak() {
+
+	// Reconnect after a device loss; skip the frame while unavailable.
+	if (not pcm and not connect()) return;
+
 	// Calculate how many samples we need based on FPS
 	// This gives us "fresh" audio data matching our update rate
 	static const uint16_t samplesNeeded = (SAMPLE_RATE / getFPS()); // e.g., 48000/30 = 1600 samples
@@ -107,9 +123,10 @@ void AlsaAudio::calcPeak() {
 		return;
 	}
 
-	// Bail on other errors
+	// Device gone: drop so the next frame reconnects.
 	if (frames < 0) {
-		LogInfo("ALSA error: " + string(snd_strerror(frames)));
+		LogWarning("ALSA error: " + string(snd_strerror(frames)) + ", reconnecting");
+		disconnect();
 		return;
 	}
 

--- a/src/animations/AlsaAudio.hpp
+++ b/src/animations/AlsaAudio.hpp
@@ -58,6 +58,20 @@ protected:
 	/// Shared PCM handle for audio capture.
 	static snd_pcm_t* pcm;
 
+	/// Capture device name, set by the first instance.
+	static string pcmName;
+
+	/**
+	 * Opens and starts the capture device.
+	 * @return true if the device is ready, false on any failure (left closed).
+	 */
+	static bool connect();
+
+	/**
+	 * Closes the capture device if open.
+	 */
+	static void disconnect();
+
 	void calcPeak() override;
 };
 

--- a/src/animations/PulseAudio.cpp
+++ b/src/animations/PulseAudio.cpp
@@ -47,7 +47,14 @@ PulseAudio::PulseAudio(StringUMap& parameters, Group* const group) :
 		return;
 	}
 
-	connect();
+	// Must not abort load: on failure fall back to the background retry.
+	try {
+		connect();
+	}
+	catch (Error& e) {
+		LogWarning("PulseAudio connection failed: " + e.getMessage() + ", will keep retrying");
+		scheduleReconnect();
+	}
 }
 
 PulseAudio::~PulseAudio() {
@@ -82,9 +89,14 @@ void PulseAudio::connect() {
 	}
 
 	pa_context_set_state_callback(context, PulseAudio::onContextSetState, nullptr);
-	pa_context_connect(context, nullptr, PA_CONTEXT_NOFLAGS, nullptr);
+
+	// Derive the user's socket from the effective uid (already dropped to it).
+	// PULSE_SERVER overrides.
+	const char* envServer = getenv("PULSE_SERVER");
+	string server(envServer ? "" : "unix:/run/user/" + to_string(getuid()) + "/pulse/native");
+	pa_context_connect(context, envServer ? nullptr : server.c_str(), PA_CONTEXT_NOFLAGS, nullptr);
 	pa_threaded_mainloop_start(tml);
-	LogDebug("PulseAudio connection initiated");
+	LogDebug("PulseAudio connecting to " + (envServer ? string(envServer) : server));
 }
 
 void PulseAudio::disconnect() {

--- a/src/devices/Adalight/Adalight.cpp
+++ b/src/devices/Adalight/Adalight.cpp
@@ -58,7 +58,7 @@ void Adalight::transfer() const {
 
 	// Data
 	serialData.insert(serialData.end(), LEDs.begin(), LEDs.begin() + numIndividualLeds);
-
+	serialData.push_back('\0');
 
 	transferToConnection(serialData);
 	/* for testing:*/

--- a/src/utilities/Serial.cpp
+++ b/src/utilities/Serial.cpp
@@ -155,7 +155,6 @@ void Serial::disconnect() {
 }
 
 void Serial::transferToConnection(vector<uint8_t>& data) const {
-	data.push_back('\0');
 	Connection::transferToConnection(data);
 	size_t totalWritten = 0;
 	while (totalWritten < data.size()) {

--- a/src/utilities/Utility.cpp
+++ b/src/utilities/Utility.cpp
@@ -143,4 +143,3 @@ const std::string Utility::getHomeDir() {
 const string Utility::getConfigDir() {
 	return string(getHomeDir() + "/.local/share/" PROJECT_NAME "/");
 }
-

--- a/src/utilities/Utility.hpp
+++ b/src/utilities/Utility.hpp
@@ -170,6 +170,7 @@ public:
 	 * @return the current user program config dir without the ending /.
 	 */
 	static const string getConfigDir();
+
 };
 
 } // namespace


### PR DESCRIPTION
Release candidate **0.7.7**

## Highlights
- Daemon now starts independently of the user session and audio availability — audio connects lazily, so the service is up as soon as the network is ready (#125).
- PulseAudio/ALSA hardening: ALSA reopens a lost capture device automatically; PulseAudio retries in the background instead of aborting startup; the daemon derives the per-user PulseAudio socket itself (#125).
- Rotator fixes: argument-parsing crash, TOS serial restrictor, hardened `colorFormat` parsing (`RGB`/`rgb`), and duplicate player/joystick request warnings (#123).
- Automated COPR/AUR release publishing and CMake/build cleanups.

See `CHANGELOG.md` for the full 0.7.7 list.