### PR TITLE
128: Ultimate I/O: derive interface, protocol and board from USB

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -322,28 +322,28 @@ install(TARGETS processLookup RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 # NanoLED output plugin
 if(ENABLE_NANOLED)
 	add_usb_device_plugin(UltimarcNanoLed
-		"src/devices/Ultimarc/FF00SharedCode.cpp;src/devices/Ultimarc/NanoLed.cpp"
+		"src/devices/Ultimarc/Ultimarc.cpp;src/devices/Ultimarc/FF00SharedCode.cpp;src/devices/Ultimarc/NanoLed.cpp"
 	)
 endif()
 
 # PacDrive output plugin
 if(ENABLE_PACDRIVE)
 	add_usb_device_plugin(UltimarcPacDrive
-		"src/devices/Ultimarc/PacDrive.cpp"
+		"src/devices/Ultimarc/Ultimarc.cpp;src/devices/Ultimarc/PacDrive.cpp"
 	)
 endif()
 
 # PacLed64 output plugin
 if(ENABLE_PACLED64)
 	add_usb_device_plugin(UltimarcPacLed64
-		"src/devices/Ultimarc/FF00SharedCode.cpp;src/devices/Ultimarc/PacLed64.cpp"
+		"src/devices/Ultimarc/Ultimarc.cpp;src/devices/Ultimarc/FF00SharedCode.cpp;src/devices/Ultimarc/PacLed64.cpp"
 	)
 endif()
 
 # Ultimate I/O output plugin
 if(ENABLE_ULTIMATEIO)
 	add_usb_device_plugin(UltimarcUltimate
-		"src/devices/Ultimarc/Ultimate.cpp"
+		"src/devices/Ultimarc/Ultimarc.cpp;src/devices/Ultimarc/Ultimate.cpp"
 	)
 endif()
 

--- a/src/devices/Adalight/Adalight.hpp
+++ b/src/devices/Adalight/Adalight.hpp
@@ -27,7 +27,7 @@
 
 #define ADALIGHT_NAME        "Adalight"
 #define ADALIGHT_MAGIC       "Ada"
-#define ADALIGHT_PRODUCT_IDS {"2e8a/1075", "2e8a/108f" "2e8a/10da", "838/8918", "ch341-uart"}
+#define ADALIGHT_PRODUCT_IDS {"2e8a/1075", "2e8a/108f", "2e8a/10da", "838/8918", "ch341-uart"}
 
 namespace LEDSpicer::Devices::Adalight {
 

--- a/src/devices/Adalight/README.md
+++ b/src/devices/Adalight/README.md
@@ -1,21 +1,60 @@
-# Adalight quickstart guide
+# Adalight
 
-# hardware I use:
-- controller:
- - [wemos d1 mini](https://www.wemos.cc/en/latest/d1/d1_mini.html)
- - [Acustomarcade PICOCRT](https://acustomarcade.com/product/ws2812b-rgb-adapter-30-rgb)
-- leds:
- - WS2812 led string, [for example](https://www.aliexpress.com/item/32243084800.html)
- - WS2812B 5V LED Strip Lights [like](https://www.amazon.com/gp/product/B0CFTP3S41)
+Serial protocol for addressable LED strips (WS2812, WS2812B and compatible). Not a single product: any controller running Adalight-compatible firmware. `Adalight` derives from `DeviceSerial`, not `DeviceUSB`.
 
+## Protocol
 
-## instructions for the d1 mini or simillar:
-First step is to follow the instructions at [WLED](https://github.com/Aircoookie/WLED)
-you are then left with a wifi + usb controlled led strip.
+Every frame is a 6 byte header followed by raw RGB data.
 
-What I do next is create a preset with leds ON but black and set it as the wled boot preset.
-When I'm ok with the settings (RGB order and max brightness mostly) and the strip is properly tested I disable the wifi (it forces you to reflash wled if you have to change something)
+| Byte | Content |
+|---|---|
+| 0-2 | magic `A` `d` `a` |
+| 3 | LED count high byte |
+| 4 | LED count low byte |
+| 5 | checksum, `high ^ low ^ 0x55` |
+| 6+ | 3 bytes per LED, in strip order |
 
-## Adalight protocol
+The count field is the number of LEDs **minus one**. `transfer()` computes it as `(channels / 3) - 1`. A 30 LED strip sends `0x00 0x1D`.
 
-https://www.partsnotincluded.com/visualizing-adalight-header-information/
+LEDSpicer appends a trailing `\0` after the data and flushes the input queue with `tcflush(fd, TCIFLUSH)` after each frame.
+
+Reference: [visualizing Adalight header information](https://www.partsnotincluded.com/visualizing-adalight-header-information/).
+
+## Serial parameters
+
+| Property | Value |
+|---|---|
+| Baud | 115200 |
+| Framing | 8N1 |
+| Reads | non-blocking |
+
+## Port detection
+
+Serial devices have no vendor-assigned identity the way HID boards do, so detection matches strings in sysfs. `Serial::findPortByUsbId()` scans `ttyUSB0`-`ttyUSB4` and `ttyACM0`-`ttyACM4`, reading `/sys/class/tty/<port>/device/uevent` and returning the first port whose uevent contains the search string.
+
+Candidates in `ADALIGHT_PRODUCT_IDS`:
+
+| Entry | Note |
+|---|---|
+| `2e8a/1075` | Raspberry Pi vendor, RP2040 class board |
+| `2e8a/108f` | Raspberry Pi vendor |
+| `2e8a/10da` | Raspberry Pi vendor |
+| `838/8918` | |
+| `ch341-uart` | matches the CH340/CH341 kernel driver name, not a USB ID |
+
+This is a heuristic, not identification. These are generic USB-serial bridge chips shared with unrelated hardware, and the CH341 entry matches a driver rather than a device. A CH340-based board that is not an LED controller will be picked up. Set `port` explicitly in the config when more than one serial device is attached.
+
+## Constraints
+
+- RGB only. The protocol has no notion of a single channel, so `Adalight` cannot address individual LEDs and `LEDs.size()` must be a multiple of 3.
+- No acknowledgement. The firmware sends nothing back, so a wrong LED count or a dropped frame is invisible to LEDSpicer. `transferFromConnection()` exists for debugging and is commented out in `transfer()`.
+- Strip order is physical. Colour channel order (RGB vs GRB) is the firmware's business; set it there, not here.
+
+## Quickstart
+
+Hardware used by the author:
+
+- Controllers: [Wemos D1 mini](https://www.wemos.cc/en/latest/d1/d1_mini.html), [Acustomarcade PICOCRT](https://acustomarcade.com/product/ws2812b-rgb-adapter-30-rgb)
+- LEDs: WS2812 string, WS2812B 5V strip
+
+For the D1 mini or similar, flash [WLED](https://github.com/Aircoookie/WLED) first, which leaves a wifi and USB controlled strip. Create a preset with the LEDs on but black and set it as the boot preset. Once the settings are right (mainly RGB order and maximum brightness) and the strip is tested, disable wifi. Changing anything after that requires reflashing WLED.

--- a/src/devices/GroovyGameGear/README.md
+++ b/src/devices/GroovyGameGear/README.md
@@ -1,0 +1,114 @@
+# GroovyGameGear
+
+USB vendor ID `0xFAFA`.
+
+| Product | PID | Boards | Implemented here |
+|---|---|---|---|
+| LED-Wiz 32 | `00F0` + boardId - 1 | 16 | `LedWiz32.{hpp,cpp}` |
+| GP-Wiz49 | `0007` + boardId - 1 | 4 | `restrictors/GPWiz49.{hpp,cpp}` |
+| GP-Wiz40 RotoX | `0035` + boardId - 1 | 4 boards, 2 rotors each | `restrictors/GPWiz40RotoX.{hpp,cpp}` |
+
+The LED-Wiz vendor and product IDs are confirmed by the Pinscape controller and by Arduino LED-Wiz clones, which reuse `fafa:00f0` to be picked up by existing software. The GP-Wiz codes come from this project's source and were not confirmed against an external reference.
+
+## LED-Wiz 32
+
+32 outputs with PWM dimming. Not RGB; each output is one channel.
+
+| Property | Value |
+|---|---|
+| Interface | 0 |
+| `wValue` | `0x0200` (report ID 0) |
+| Message | 8 bytes |
+| Inter-message delay | 1000 us |
+
+Two message types, told apart by the first byte.
+
+### SBA, first byte 64
+
+Enables outputs and sets the global pulse speed.
+
+| Byte | Content |
+|---|---|
+| 0 | `64` |
+| 1-4 | on/off bitmasks for outputs 1-32, one bit per output |
+| 5 | global pulse speed, 1 to 7 |
+| 6-7 | zero |
+
+Sent once in `afterClaimInterface()` as `{64, 255, 255, 255, 255, 1, 0, 0}`: every output enabled, fastest pulse. This also initialises the board's four controller ICs.
+
+### PBA, any other first byte
+
+Sets the per-output profile. 32 values sent as 4 messages of 8 bytes, in output order.
+
+| Value | Meaning |
+|---|---|
+| 0 | off |
+| 1-48 | PWM duty, 48 is maximum |
+| 49 | solid on, not PWM |
+| 129-132 | automated pulse modes, speed from the SBA global pulse speed |
+
+LEDSpicer maps 0-255 onto 0-48 with `48 * (intensity / 255.0)`, so value 49 is never sent. The difference between 48 and 49 is PWM at full duty versus a steady line. Visually identical on most LEDs; 49 matters for non-LED loads driven through the outputs.
+
+PBA is a profile, not an on/off control. Vendor documentation warns against using it for switching. LEDSpicer uses it as the only write path, having enabled everything once through SBA, which is the standard approach.
+
+The 1000 us delay between messages is required. The board drops messages sent back to back.
+
+Output order in `drawHardwareLedMap()` is a left column of outputs 1-16 and a right column of 32 down to 17.
+
+## GP-Wiz49
+
+49 way joystick with selectable output mapping.
+
+| Property | Value |
+|---|---|
+| Interface | 0 |
+| `wValue` | `0x0200` |
+| Message | `{204, mode}` |
+
+| Mode | Meaning | LEDSpicer `Ways` |
+|---|---|---|
+| 1 | 49 way, raw | `analog`, `mouse` |
+| 2 | progressive 49 | `w49` |
+| 3 | 8 way | default |
+| 4 | 4 way | `w4` |
+| 5 | 4 way diagonal | `w4x` |
+| 6 | 2 way horizontal | `w2` |
+| 7 | 2 way vertical | `w2v` |
+| 8 | 16 way, large centre dead zone | `w16` |
+
+Adding 10 to the mode selects the Williams Sinistar variant of the same mapping, enabled with the `williams` option. Modes 11-18 are therefore valid and are the documented way to drive a Sinistar-style 49 way stick.
+
+This is a mapping change, not a mechanical one. Nothing moves; the board reinterprets the sensor.
+
+## GP-Wiz40 RotoX
+
+Two rotary sticks per board, addressed together in one message.
+
+| Property | Value |
+|---|---|
+| Interface | 0 |
+| `wValue` | `0x0200` |
+| Message | `{207, speedOn, speedOff, flags}` |
+| Rotors per board | 2 |
+
+Flags byte:
+
+| Bit | Value | Meaning |
+|---|---|---|
+| 0 | 1 | 12 way rotary on stick 1 |
+| 1 | 2 | 12 way rotary on stick 2 |
+| 4 | 16 | 8 way rotary on stick 1 |
+| 5 | 32 | 8 way rotary on stick 2 |
+
+Both rotors are set in a single write. Nothing is sent when the flags byte is zero, that is when no configured player asked for a rotary mode.
+
+`speedOn` and `speedOff` control the rotation timing and are members of the class rather than derived from the profile.
+
+Only `rotary8` and `rotary12` reach this board. Any other `Ways` value leaves the corresponding rotor untouched.
+
+## Known gaps
+
+- GP-Wiz vendor and product IDs unconfirmed outside this source tree.
+- LED-Wiz value 49 and the 129-132 pulse modes are unreachable through LEDSpicer.
+- The LED-Wiz SBA global pulse speed is fixed at 1 and not configurable.
+- `speedOn` and `speedOff` on the RotoX are not exposed in the config.

--- a/src/devices/RaspberryPiGPIO/README.md
+++ b/src/devices/RaspberryPiGPIO/README.md
@@ -1,0 +1,51 @@
+# Raspberry Pi GPIO
+
+The host's own GPIO header, driven through [pigpio](https://abyz.me.uk/rpi/pigpio/). No USB, no serial, no connection at all: `RaspberryPi` derives from `Device` directly rather than `DeviceUSB` or `DeviceSerial`.
+
+Built only when `ENABLE_RASPBERRYPI` is on, which also requires `libpigpio`.
+
+| Property | Value |
+|---|---|
+| Channels | 28 (BCM GPIO 1 to 28) |
+| Dimming | software PWM, 0 to 255 |
+| Transfer mode | `RPI_TRANSFER 1`, individual |
+| Board ID | none |
+
+## Addressing
+
+LEDSpicer LED index `n` maps to BCM GPIO `n + 1`. The offset comes from `openHardware()`, which computes each element's GPIO from its position in the buffer:
+
+```
+gpioled = led - firstled + 1
+```
+
+So LED 0 is GPIO 1, LED 27 is GPIO 28. GPIO 0 is not reachable.
+
+## Behaviour
+
+`openHardware()` walks the registered elements and calls `gpioSetMode(pin, PI_OUTPUT)` only for pins an element actually claims, collecting them into `usedleds`. `transfer()` then calls `gpioPWM()` for those pins alone. Unassigned pins are never touched and keep whatever mode the system gave them, which is what makes it safe to share the header with other functions.
+
+`resetLeds()` writes PWM 0 to the used pins and clears the buffer.
+
+## Single instance
+
+`gpioInitialise()` is process wide, so the class guards it with a static `initialized` flag and throws on a second instance:
+
+```
+<name> device can only be loaded once
+```
+
+Two Raspberry Pi devices in one config is a configuration error, not a supported multi-board setup.
+
+## Constraints
+
+- pigpio requires root, or the pigpio daemon with appropriate permissions. LEDSpicer drops privileges after devices are initialised, so initialisation must happen while still root.
+- Software PWM on many pins costs CPU. There is no hardware PWM path here; `gpioPWM()` is used for every pin regardless of whether it is one of the pins capable of hardware PWM.
+- No current limiting. Pins source a few milliamps and need a driver stage for anything brighter than an indicator LED.
+- Pin numbering is BCM, not physical header position. `drawHardwareLedMap()` prints the header layout with the ground and power positions marked `G` and `+`.
+
+## Known gaps
+
+- The constructor ignores its `options` argument entirely, so no per-board configuration reaches the class.
+- No mapping from LED index to a chosen GPIO. The `+1` offset is fixed, so a config cannot skip pins reserved for I2C, SPI or UART; it can only leave them unassigned.
+- Hardware PWM pins are not treated differently from the rest.

--- a/src/devices/Ultimarc/FF00SharedCode.cpp
+++ b/src/devices/Ultimarc/FF00SharedCode.cpp
@@ -19,21 +19,10 @@ void FF00SharedCode::resetLeds() {
 
 	// Turn off all LEDs and internal buffer.
 	setLeds(0);
-	data[0] = 0x80; //FIXME this may be wrong.
+	data[FF00_MSG_COMMAND] = 0x80;
 	transferToConnection(data);
 }
 
 void FF00SharedCode::transfer() const {
-
-	// Send FE00 command.
-	vector<uint8_t> data FF00_MSG(0xFE, 0);
-	transferToConnection(data);
-
-	// Send pairs.
-	for (uint16_t c = 0; c < LEDs.size(); c+=2) {
-		data.clear();
-		data.push_back(LEDs[c]);
-		data.push_back(LEDs[c + 1]);
-		transferToConnection(data);
-	}
+	transferPairs(FF00_MSG(0, 0), FF00_MSG_COMMAND);
 }

--- a/src/devices/Ultimarc/FF00SharedCode.hpp
+++ b/src/devices/Ultimarc/FF00SharedCode.hpp
@@ -11,6 +11,8 @@
 #pragma once
 
 #define FF00_MSG(byte1, byte2) {byte1, byte2}
+/// Index of the command byte inside FF00_MSG.
+#define FF00_MSG_COMMAND 0
 #define FF00_TRANSFER 2 // Batches.
 
 namespace LEDSpicer::Devices::Ultimarc {

--- a/src/devices/Ultimarc/README.md
+++ b/src/devices/Ultimarc/README.md
@@ -1,0 +1,220 @@
+# Ultimarc
+
+USB vendor ID `0xD209` for every board below. Verified against [PacDriveSDK](https://github.com/benbaker76/PacDriveSDK) (`dll/PacDrive.h`, `dll/PacDrive.cpp`), [Ultimarc-linux](https://github.com/katie-snow/Ultimarc-linux), [QtPyUltimarc](https://github.com/katie-snow/QtPyUltimarc) and `lsusb` output in issues #16 and #17.
+
+## Product codes
+
+| Product | PID block | Boards | Implemented here |
+|---|---|---|---|
+| PacDrive | `1500` | 4, by `bcdDevice` | `PacDrive.{hpp,cpp}` |
+| PacLed64 | `1401`-`1408` | see note | `PacLed64.{hpp,cpp}` |
+| NanoLed | `1481`-`1484` | 4 | `NanoLed.{hpp,cpp}` |
+| I-PAC Ultimate I/O | `0410`-`0413` | 2, block also encodes the mode | `Ultimate.{hpp,cpp}` |
+| ServoStik | `1700` | by bus position | `restrictors/ServoStik.{hpp,cpp}` |
+| UltraStik360 (2015+) | `0511` | 4 | `restrictors/UltraStik360.{hpp,cpp}` |
+| UltraStik360 (pre 2015) | `0501` | 4 | not handled, interface is 0 not 2 |
+| U-HID | `1501`-`1508` | 8 | not implemented |
+| USB Button | `1200` | 1 | not implemented |
+| Trackball / Spinner | `15a1` | 1 | not implemented, input only, no LEDs |
+
+The SDK accepts `1401`-`1408` for PacLed64, but an SDK accept range is not a board count: the Ultimate block is 4 codes for 2 boards. `PAC_LED64_MAX_BOARDS` is 4 here and no second source was found. Settle it by setting board ID 5 in the Ultimarc tool and checking whether it enumerates as `d209:1405`.
+
+## Transport
+
+All boards are HID. LEDs are written with a control transfer, never an endpoint.
+
+| Field | Value |
+|---|---|
+| `bmRequestType` | `0x21` (host to device, class, interface) |
+| `bRequest` | `0x09` (SET_REPORT) |
+| `wValue` | `0x0200 \| reportId` |
+| `wIndex` | interface number |
+
+The report ID appears twice, in the low byte of `wValue` and as the first payload byte. Ultimarc-linux and QtPyUltimarc both do this and the boards expect it.
+
+## PacDrive
+
+16 on/off outputs, no dimming. `Monochromatic` applies a `changePoint` threshold to turn LEDSpicer intensities into bits.
+
+| Property | Value |
+|---|---|
+| Interface | 0 |
+| `wValue` | `0x0200` (report ID 0) |
+| Message | 4 bytes |
+| Board ID | `bcdDevice`, not the PID (`isProductBasedId()` returns false) |
+
+Message layout:
+
+| Byte | SDK | LEDSpicer |
+|---|---|---|
+| 0 | `0x00` | `0x00` |
+| 1 | `0xdd` | `0x00` |
+| 2 | outputs 8-15 bitmask | outputs 8-15 bitmask |
+| 3 | outputs 0-7 bitmask | outputs 0-7 bitmask |
+
+Byte 1 differs. The SDK writes the same `0xdd` marker that ServoStik uses; LEDSpicer writes zero and works in the field, so the firmware appears to ignore it. Not verified on hardware.
+
+PacDrive is the only Ultimarc board that identifies its position through `bcdDevice`. Ultimarc ships it configured for up to 4 boards, more on request.
+
+Confirmed by `lsusb -v`: a board 1 unit reports `bcdDevice 0.01`, that is `0x0001`, so the `desc.bcdDevice == boardId` test in `USB::connect()` matches against a plain decimal `boardId`. The comparison is BCD against decimal and only stays correct while `boardId` is 9 or less, which the 4 board maximum guarantees. It also publishes a single HID interface numbered 0, matching `PAC_DRIVE_INTERFACE`, one IN endpoint at `0x81`, a 33 byte report descriptor, and no OUT endpoint.
+
+`bcdDevice` therefore means two different things across this vendor: a board identifier on PacDrive, and a firmware version on the Ultimate I/O, where it carries no usable information. Nothing else keys off it.
+
+## PacLed64 and NanoLed
+
+Both use the pair stream, implemented in `FF00SharedCode` on top of `Ultimarc::transferPairs()`.
+
+| Property | PacLed64 | NanoLed |
+|---|---|---|
+| LEDs | 64 | 60 |
+| Interface | 1 | 1 |
+| `wValue` | `0x0200` (report ID 0) | `0x0200` |
+| Message | 2 bytes | 2 bytes |
+| PID | `0x1401 + boardId - 1` | `0x1481 + boardId - 1` |
+
+Message is `{command, value}`. Commands:
+
+| Command | Meaning |
+|---|---|
+| `0x00`-`0x3F` | LED index, value is the intensity |
+| `0x40` | flash speed (PacLed64 only) |
+| `0x80` | all LEDs, value is the intensity |
+| `0x89` | random states |
+| `0xC0` | fade rate, value is the rate |
+| `0xFE` | start of a full stream, followed by 32 (PacLed64) or 30 (NanoLed) pairs |
+
+`group | 0x80` addresses a group of 8 outputs, with the group number shifted by 8 above group 8 (`(group > 8 ? group + 8 : group) | 0x80`). Not used here.
+
+Both constructors pass interface 0 and `FF00SharedCode::afterConnect()` is empty, so the interface stays 0 rather than the 1 the headers define. **Interface 0 is correct and the constant is wrong.** A PacLed64 `lsusb -v` shows `bNumInterfaces 1`, a single HID interface numbered 0, one IN endpoint at `0x81`, and a report descriptor of 35 bytes. There is no interface 1 to claim. `PAC_LED64_INTERFACE` and `NANO_LED_INTERFACE` are dead constants.
+
+The SDK rejects a NanoLed that does not present the old driver collection, so NanoLed has no fast path.
+
+## I-PAC Ultimate I/O
+
+Keyboard and joystick encoder plus 96 LED channels (32 RGB), 256 levels. The only Ultimarc board whose USB identity changes at runtime.
+
+### Multi-Mode
+
+Firmware 1.50+ switches operating mode on the board itself. Mode is not a config value and cannot be forced from the host.
+
+| Mode | Presents as | PID | LEDs |
+|---|---|---|---|
+| Keyboard (default) | keyboard, mouse | `0410` + board | yes |
+| Dinput | keyboard, mouse, 2 gamepads | `0412` + board | yes |
+| Xinput | Xbox 360 controller | `045e:028e` | no |
+
+In Xinput the board leaves the `d209` space entirely and publishes no LED interface. Reset to keyboard by holding P1SW1 while connecting USB.
+
+`PID = 0x0410 + (dinput ? 2 : 0) + (boardId - 1)`. Board 2 needs Ultimarc's "ID #2" firmware. `0413` is inferred from the pattern; `0410`, `0411` and `0412` are observed.
+
+### Interfaces
+
+The LED collection is the last interface. How many precede it depends on the mode, not the firmware version.
+
+| Mode | Interfaces | LED interface |
+|---|---|---|
+| Keyboard, or 1.4x firmware | 3 | 2 |
+| Dinput, or 1.3x firmware | 4 | 3 |
+
+Confirmed by `lsusb -v` on a keyboard mode board: three HID interfaces, 0 declaring boot subclass with protocol 1 (keyboard), 1 declaring boot subclass with protocol 2 (mouse), and 2 declaring subclass 0 with protocol 0, a 64 byte IN endpoint at `0x84` and a 136 byte report descriptor. Interface 2 is both the last one and the only one that is neither keyboard nor mouse, so either rule picks it. In Dinput the gamepad would also be subclass 0, which is why the position rule is the one used.
+
+Note that interface 2 publishes **no OUT endpoint**. LED writes go through control transfers on endpoint 0, which is why `USB::send()` works without ever touching the interface's own endpoint.
+
+`bcdDevice & 0x40` was used for this and is wrong. The bit only distinguishes the split firmware naming, where the middle digit is `3` with a gamepad and `4` without. It cannot see a runtime mode switch, so on Multi-Mode firmware it always answers "no gamepad", which is false in Dinput mode. Ultimarc-linux carries the same bug; QtPyUltimarc hardcodes interface 2 and does not support Dinput.
+
+The version the board reports is not the version the firmware notes use. A board running current firmware reported `bcdDevice 0.49`, not a `1.5x` value. `0x49 & 0x40` is set, so the old test still landed on interface 2 in keyboard mode, by luck rather than by meaning. Do not map `bcdDevice` onto the firmware table below.
+
+### Firmware history
+
+| Versions | Behaviour |
+|---|---|
+| 1.22-1.33 | keyboard only, single firmware |
+| 1.34-1.39 | keyboard with gamepad, always both, no Xinput, incompatible with RetroPie. Still offered as alternative firmware |
+| 1.44-1.49 | keyboard and mouse, no gamepad |
+| 1.50-1.56 | Multi-Mode, one device type at a time |
+| 1.57 | adds any-button mode switching, not on all boards |
+
+Shift functionality must be enabled before flashing Multi-Mode or mode switching will not work. Default shift control is Start1.
+
+### LED protocols
+
+Two HID collections, distinguished by usage page. Both can exist on one board; the SDK's `RemoveNewDriver()` merges them by matching product ID, and takes the fast path only when the merge produced a pointer.
+
+| | Old collection | Fast collection |
+|---|---|---|
+| Usage page, usage | 1, 0 | 6, 0 |
+| Output report length | non-zero | 97 |
+| Report ID | 3 | 4 |
+| Full update | `0xFE` then 48 pairs | one packet, 96 bytes |
+
+Usage 0 on page 1 is what separates the LED collection from keyboard (usage 6), mouse (2) and gamepad (5). Reading the report descriptor of the LED interface answers both which interface and which protocol.
+
+The 5 byte message, agreed by all three reference implementations:
+
+| Byte | Content |
+|---|---|
+| 0 | `0x03`, the report ID |
+| 1 | command |
+| 2 | value |
+| 3-4 | reserved, zero |
+
+Commands match PacLed64 (`0x80` all, `0x89` random, `0xC0` fade rate, `0xFE` stream start, otherwise the LED index).
+
+`IPAC_ULTIMATE_WVALUE` stays `0x0203` on the fast path even though the payload's report ID is `0x04`. That combination has shipped and works. If a board detects the fast collection but stays dark, try `0x0204`.
+
+### Configuration channel
+
+Not implemented here, documented by Ultimarc-linux. Pin assignments, macros and debounce are written to the same interface with a 260 byte payload prefixed `0x50 0xdd 0x0f 0x00`, and read back with `0x59 0xdd 0x0f 0x00`. `IPACULTIMATE_DATA_SIZE` is 260. Board ID is also set this way, which is how the "ID #2" firmware is applied.
+
+## ServoStik
+
+Two-position gate, 4 way or 8 way only.
+
+| Property | Value |
+|---|---|
+| PID | `1700`, fixed |
+| Interface | 0 |
+| `wValue` | `0x0200` |
+| Message | `{0x00, 0xdd, 0x00, ways}` where ways is 0 for 4 way and 1 for 8 way |
+| Max players | 2 |
+
+The PID never changes, so multiple boards are told apart by bus and port position (`isNonBasedId()`). One command moves both restrictors on a board, so the first player's setting wins and the rest are ignored.
+
+The board cannot be queried for its current position. LEDSpicer caches the last value in `~/.config/ledspicer/servostik/last_<profile>.dat` to skip redundant moves. Deleting the file forces the next rotation.
+
+## UltraStik360
+
+Analog joystick with a downloadable 9x9 restrictor map.
+
+| Property | Value |
+|---|---|
+| PID | `0511 + boardId - 1` (2015+), `0501` pre 2015 |
+| Interface | 2 (2015+), 0 pre 2015 |
+| `wValue` | `0x0200` |
+| Transfer | 96 bytes in 24 chunks of 4 |
+
+Payload layout:
+
+| Byte | Content |
+|---|---|
+| 0 | keep analog: `0x50` off, `0x11` on (2015+) |
+| 1 | map size, 9 |
+| 2 | mechanical restrictor: `0x10` off, `0x09` on |
+| 3-10 | cell borders, 8 values |
+| 11-92 | map data, 9 rows of 9 |
+| 95 | pre 2015 only: `0xFF` RAM, `0x00` flash. Must be 0 on 2015+ |
+
+Maps come from `.um` files in `PROJECT_DATA_DIR/umaps/`. Default borders are `{30,58,86,114,142,170,198,226}`. Parsed maps are cached per `Ways` value for the process lifetime.
+
+Pre 2015 boards are not supported: the PID and the interface both differ and nothing selects between them.
+
+Confirmed by `lsusb -v`: player 1 enumerates as `d209:0511` and player 2 as `d209:0512`, so the PID increment is real, and each publishes three HID interfaces with the control interface at number 2, matching `ULTRASTIK_INTERFACE`.
+
+## Known gaps
+
+- PacDrive byte 1 differs from the SDK, see above.
+- PacLed64 and NanoLed claim interface 0 while their headers name interface 1.
+- Pre 2015 UltraStik360 unreachable.
+- U-HID and USB Button are in the Ultimarc HID space and unimplemented.
+- Ultimate `0413` unobserved.
+- Whether "ID #2" board firmware and Multi-Mode mode switching combine is undocumented in every source checked.

--- a/src/devices/Ultimarc/Ultimarc.cpp
+++ b/src/devices/Ultimarc/Ultimarc.cpp
@@ -1,7 +1,7 @@
 /* -*- Mode: C; indent-tabs-mode: t; c-basic-offset: 4; tab-width: 4 -*-  */
 /**
- * @file      Ultimarc.hpp
- * @since     Sep 27, 2018
+ * @file      Ultimarc.cpp
+ * @since     Jul 27, 2026
  * @author    Patricio A. Rossi (MeduZa)
  *
  * @copyright Copyright © 2018 - 2026 Patricio A. Rossi (MeduZa)
@@ -20,39 +20,20 @@
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "devices/DeviceUSB.hpp"
+#include "Ultimarc.hpp"
 
-#pragma once
+using namespace LEDSpicer::Devices::Ultimarc;
 
-namespace LEDSpicer::Devices::Ultimarc {
+void Ultimarc::transferPairs(vector<uint8_t> message, uint8_t command) const {
 
-/**
- * Ultimarc family data and definitions.
- */
-class Ultimarc : public DeviceUSB {
+	// Announce the stream.
+	message[command]     = 0xFE;
+	message[command + 1] = 0;
+	transferToConnection(message);
 
-public:
-
-	using DeviceUSB::DeviceUSB;
-
-	uint16_t getVendor() const {
-		return ULTIMARC_VENDOR;
+	for (uint16_t c = 0; c < LEDs.size(); c += 2) {
+		message[command]     = LEDs[c];
+		message[command + 1] = LEDs[c + 1];
+		transferToConnection(message);
 	}
-
-protected:
-
-	void afterClaimInterface() override {}
-
-	/**
-	 * Streams the LED buffer as a 0xFE reset followed by intensity pairs.
-	 * Only the byte order is common between the boards that use this, the report framing is not,
-	 * so every caller provides its own message and says where the command byte sits in it.
-	 *
-	 * @param message the device report framing.
-	 * @param command index of the command byte inside the message, the value byte follows it.
-	 */
-	void transferPairs(vector<uint8_t> message, uint8_t command) const;
-
-};
-
-} // namespace
+}

--- a/src/devices/Ultimarc/Ultimate.cpp
+++ b/src/devices/Ultimarc/Ultimate.cpp
@@ -32,33 +32,80 @@ void Ultimate::resetLeds() {
 
 	// Turn off all LEDs and internal buffer.
 	setLeds(0);
-	data[3] = 0x80;
+	data[ULTIMAGE_MSG_COMMAND] = 0x80;
 	transferToConnection(data);
 }
 
 void Ultimate::afterConnect() {
 
-	// Detect interface.
-	LogDebug("Detecting interface");
+	libusb_config_descriptor* configuration = nullptr;
 
-	libusb_device* device = libusb_get_device(handle);
+	if (libusb_get_active_config_descriptor(libusb_get_device(handle), &configuration) != LIBUSB_SUCCESS)
+		throw Error("Unable to read the configuration descriptor for ") << getFullName();
 
-	if (not device)
-		throw Error("Unable to retrieve device information");
+	/*
+	 * The keyboard, the mouse and, when the board is in a game controller mode, the gamepad
+	 * come first, so the LEDs are always on the last interface. How many precede it depends
+	 * on the mode the board was switched to, not on the firmware version.
+	 */
+	const uint8_t
+		count    = configuration->bNumInterfaces,
+		position = count - 1;
+	interface    = configuration->interface[position].altsetting[0].bInterfaceNumber;
+	reportLength = reportDescriptorLength(configuration, position);
 
-	libusb_device_descriptor descriptor;
+	libusb_free_config_descriptor(configuration);
 
-	libusb_get_device_descriptor(device, &descriptor);
+	LogInfo(getFullName() + " uses interface " + to_string(interface) + " of " + to_string(count));
+}
 
-	// Detect Game Controller mode (will shift the interface by one).
-	if ((descriptor.bcdDevice & 0x40)) {
-		LogInfo("No Game Controller mode detected");
-		interface = IPAC_ULTIMATE_INTERFACE;
+void Ultimate::afterClaimInterface() {
+
+	// Claiming detached the kernel driver, so the report descriptor can be read now.
+	hasFastLedReport = detectFastLedReport(reportLength);
+	LogInfo(getFullName() + (hasFastLedReport ? " accepts single packet updates" : " uses paired updates"));
+}
+
+uint16_t Ultimate::reportDescriptorLength(const libusb_config_descriptor* configuration, uint8_t position) const {
+
+	const libusb_interface_descriptor& descriptor = configuration->interface[position].altsetting[0];
+
+	// The HID class descriptor trails the interface descriptor and sizes what is subordinate to it.
+	for (int c = 0; c + 8 < descriptor.extra_length and descriptor.extra[c]; c += descriptor.extra[c])
+		if (descriptor.extra[c + 1] == HID_DESCRIPTOR and descriptor.extra[c + 6] == HID_REPORT_DESCRIPTOR)
+			return descriptor.extra[c + 7] | (descriptor.extra[c + 8] << 8);
+
+	throw Error("No HID report descriptor on interface ") << to_string(interface) << " of " << getFullName();
+}
+
+bool Ultimate::detectFastLedReport(uint16_t length) const {
+
+	vector<uint8_t> report(length);
+
+	const int read = libusb_control_transfer(
+		handle,
+		LIBUSB_ENDPOINT_IN | LIBUSB_RECIPIENT_INTERFACE,
+		LIBUSB_REQUEST_GET_DESCRIPTOR,
+		HID_REPORT_DESCRIPTOR << 8,
+		interface,
+		report.data(),
+		length,
+		USB_TIMEOUT
+	);
+
+	if (read < 0)
+		throw Error("Unable to read the report descriptor of ") << getFullName() << ": " << libusb_error_name(read);
+
+	// Only the collection that takes every LED in one packet declares this usage page.
+	for (int c = 0; c + 1 < read;) {
+		const uint8_t size = report[c] & HID_ITEM_SIZE;
+		if (size == 1 and (report[c] & HID_ITEM_TAG) == HID_ITEM_USAGE_PAGE and report[c + 1] == IPAC_ULTIMATE_FAST_PAGE)
+			return true;
+		// A size of 3 means four bytes of data, every other size means as many bytes as its value.
+		c += 1 + (size == 3 ? 4 : size);
 	}
-	else {
-		LogInfo("Game Controller mode detected");
-		interface = IPAC_ULTIMATE_INTERFACE + 1;
-	}
+
+	return false;
 }
 
 void Ultimate::drawHardwareLedMap() {
@@ -87,12 +134,33 @@ void Ultimate::drawHardwareLedMap() {
 
 void Ultimate::transfer() const {
 
+	if (not hasFastLedReport) {
+		transferPairs(ULTIMAGE_MSG(0, 0), ULTIMAGE_MSG_COMMAND);
+		return;
+	}
+
 	vector<uint8_t> load;
-	load.push_back(0x04);
+	load.push_back(IPAC_ULTIMATE_FAST_REPORT);
 	load.insert(load.end(), LEDs.begin(), LEDs.end());
 	transferToConnection(load);
 }
 
 uint16_t Ultimate::getProduct() const {
-	return IPAC_ULTIMATE_PRODUCT + boardId - 1;
+	return IPAC_ULTIMATE_PRODUCT;
+}
+
+bool Ultimate::matchesSignature(const libusb_device_descriptor& descriptor) const {
+
+	if (descriptor.idVendor != getVendor())
+		return false;
+
+	if (descriptor.idProduct < IPAC_ULTIMATE_PRODUCT or descriptor.idProduct > IPAC_ULTIMATE_PRODUCT_END)
+		return false;
+
+	// The low bit of the offset is the board, the high bit is the mode, which is the board's to pick.
+	return ((descriptor.idProduct - IPAC_ULTIMATE_PRODUCT) & 0x01) == boardId - 1;
+}
+
+string Ultimate::notFoundHint() const {
+	return ", the board may be in Xinput mode, where it has no LED interface";
 }

--- a/src/devices/Ultimarc/Ultimate.hpp
+++ b/src/devices/Ultimarc/Ultimate.hpp
@@ -25,14 +25,34 @@
 #pragma once
 
 #define IPAC_ULTIMATE_NAME       "Ultimarc Ipac Ultimate IO"
-#define IPAC_ULTIMATE_PRODUCT    0x0410
 #define IPAC_ULTIMATE_WVALUE     0x0203
-#define IPAC_ULTIMATE_INTERFACE  2
 #define IPAC_ULTIMATE_LEDS       96
-#define IPAC_ULTIMAGE_MAX_BOARDS 4
+#define IPAC_ULTIMAGE_MAX_BOARDS 2
 #define IPAC_ULTIMAGE_TRANSFER   0// All.
 
-#define ULTIMAGE_MSG(byte1, byte2) {0x03, 0, 0, byte1, byte2}
+/// First and last product code of the block the board positions and the operating modes share.
+#define IPAC_ULTIMATE_PRODUCT     0x0410
+#define IPAC_ULTIMATE_PRODUCT_END 0x0413
+
+/// Report ID of the single packet that carries every LED at once.
+#define IPAC_ULTIMATE_FAST_REPORT 0x04
+/// HID usage page of the collection that publishes the single packet report.
+#define IPAC_ULTIMATE_FAST_PAGE   6
+
+/// Descriptor type of the HID class descriptor.
+#define HID_DESCRIPTOR        0x21
+/// Descriptor type of the HID report descriptor.
+#define HID_REPORT_DESCRIPTOR 0x22
+/// Mask for the data size carried by a HID short item.
+#define HID_ITEM_SIZE         0x03
+/// Mask for the type and the tag of a HID short item.
+#define HID_ITEM_TAG          0xFC
+/// The HID short item tag that declares a usage page.
+#define HID_ITEM_USAGE_PAGE   0x04
+
+#define ULTIMAGE_MSG(byte1, byte2) {0x03, byte1, byte2, 0, 0}
+/// Index of the command byte inside ULTIMAGE_MSG.
+#define ULTIMAGE_MSG_COMMAND 1
 
 namespace LEDSpicer::Devices::Ultimarc {
 
@@ -65,11 +85,49 @@ public:
 
 	uint16_t getProduct() const override;
 
+	/**
+	 * The product code block is shared by the board position and the operating mode, so the
+	 * board is read back from it instead of being used to compute it.
+	 */
+	bool matchesSignature(const libusb_device_descriptor& descriptor) const override;
+
 	void resetLeds() override;
 
 protected:
 
+	/**
+	 * True when the board publishes the collection that accepts every LED in one packet.
+	 * Stays false on DRY_RUN builds, where the probe never runs.
+	 */
+	bool hasFastLedReport = false;
+
+	/// Length of the LED interface report descriptor, read while connecting.
+	uint16_t reportLength = 0;
+
 	void afterConnect() override;
+
+	void afterClaimInterface() override;
+
+	string notFoundHint() const override;
+
+	/**
+	 * Reads how long the HID report descriptor of an interface is.
+	 *
+	 * @param configuration the active configuration descriptor.
+	 * @param position index of the interface inside the configuration.
+	 * @return the length.
+	 * @throws Error if the interface publishes no HID report descriptor.
+	 */
+	uint16_t reportDescriptorLength(const libusb_config_descriptor* configuration, uint8_t position) const;
+
+	/**
+	 * Reads the report descriptor of the claimed interface and looks for the collection
+	 * that publishes the single packet report.
+	 *
+	 * @param length the report descriptor length.
+	 * @return true when the board accepts the single packet report.
+	 */
+	bool detectFastLedReport(uint16_t length) const;
 
 };
 

--- a/src/devices/WolfWareTech/README.md
+++ b/src/devices/WolfWareTech/README.md
@@ -1,0 +1,92 @@
+# WolfWare Tech
+
+USB vendor ID `0x03EB`. This is Atmel's generic vendor ID, not exclusive to WolfWare Tech, so the product ID must always be checked as well. `USB::connect()` matches both.
+
+| Product | PID | Boards | Implemented here |
+|---|---|---|---|
+| Howler | `6800`-`6803` | 4 | `Howler.{hpp,cpp}` |
+
+Verified against [libhowler](https://github.com/Mokosha/libhowler) (`howler.h`, `usb_linux.c`).
+
+## Howler
+
+Arcade controller with 96 LED channels, 32 RGB LEDs.
+
+| Group | RGB LEDs | Channels |
+|---|---|---|
+| Buttons | 26 | 78 |
+| Joysticks | 4 | 12 |
+| High power outputs | 2 | 6 |
+| Total | 32 | 96 |
+
+## Transport
+
+Unlike every other USB board here, the Howler uses interrupt transfers, not control transfers. `Howler::send()` overrides `USB::send()` for this.
+
+| Property | Value |
+|---|---|
+| Interface | 0 |
+| OUT endpoint | `0x02` |
+| IN endpoint | `0x81` |
+| Transfer size | 24 bytes, fixed, both directions |
+
+The header names these `HOWLER_IN_EP 0x02` and `HOWLER_OUT_EP 0x81`, which reads as the device's point of view: data goes *in to* the Howler on `0x02` and *out of* it on `0x81`. USB names endpoints from the host's point of view, where bit 7 of the address is the direction: `0x02` is OUT (host to device) and `0x81` is IN (device to host). So `send()` writing to `HOWLER_IN_EP` is correct, and looks wrong at a glance. `HOWLER_OUT_EP` is unused; nothing reads from the board.
+
+## Message format
+
+Every command is 24 bytes and starts with the magic byte `0xCE`.
+
+| Byte | Content |
+|---|---|
+| 0 | `0xCE` |
+| 1 | command |
+| 2+ | command arguments, zero padded to 24 |
+
+`HOWLER_WVALUE` is defined as `0x00CE` and used both as the nominal control value and, truncated to `uint8_t`, as this magic byte.
+
+### Command set
+
+| Code | Command | Used here |
+|---|---|---|
+| `0x01` | set RGB LED | no |
+| `0x02` | set individual LED | no |
+| `0x03` | set input | no |
+| `0x04` | get input | no |
+| `0x05` | set default | no |
+| `0x06` | set global brightness | no |
+| `0x07` | set RGB LED default | no |
+| `0x08` | get RGB LED | no |
+| `0x09` | set RGB LED bank | yes |
+| `0xA0` | get firmware revision | no |
+| `0xAC` | get accelerometer data | no |
+
+The board carries an accelerometer readable with `0xAC`, and can store a power-on default LED state with `0x05` and `0x07`. Neither is exposed by LEDSpicer.
+
+### Bank writes
+
+The 96 channels are six banks of 16. One full frame is six `0x09` messages.
+
+| Byte | Content |
+|---|---|
+| 0 | `0xCE` |
+| 1 | `0x09` |
+| 2 | bank number, 1 to 6 |
+| 3-18 | 16 channel values |
+| 19-23 | zero padding |
+
+Banks are not contiguous slices of the channel array. `howlerBankA` and `howlerBankB` in `Howler.hpp` hold the scatter tables: odd banks (1, 3, 5) take one interleave, even banks (2, 4, 6) another, and the `row` argument (0, 1, 2) selects the red, green or blue plane. libhowler carries the same tables in `led_bank_tables.c` as `howler_button_to_bank`, `howler_joystick_to_bank` and `howler_hp_led_to_bank`.
+
+Channel layout in `drawHardwareLedMap()`:
+
+| Channels | Assignment |
+|---|---|
+| 0-11 | joysticks 1 to 4, 3 each |
+| 12-89 | buttons 1 to 26, 3 each |
+| 90-95 | high power outputs 1 and 2, 3 each |
+
+## Known gaps
+
+- Endpoint macros are named from the device's point of view, not the host's, so writes go to `HOWLER_IN_EP`. Correct, but it reads as a mistake.
+- Global brightness (`0x06`) is not used, so LEDSpicer drives full range through the bank values only.
+- No firmware revision check, so board revision differences would go unnoticed.
+- libhowler lists PIDs `6800`-`6803`, matching the 4 board maximum here. Not verified on more than one board.

--- a/src/restrictors/README.md
+++ b/src/restrictors/README.md
@@ -1,0 +1,154 @@
+# Restrictors
+
+Joystick gate and mapping hardware, driven by `rotator`, not by the daemon. Same plugin and connection model as devices: `Restrictor : Hardware`, then `RestrictorUSB : USB, Restrictor` or `RestrictorSerial : Serial, Restrictor`.
+
+Vendor detail for the Ultimarc and GroovyGameGear units lives with the rest of that vendor's hardware:
+
+| Hardware | Vendor | Document |
+|---|---|---|
+| ServoStik, UltraStik360 | Ultimarc | [`devices/Ultimarc/README.md`](../devices/Ultimarc/README.md) |
+| GP-Wiz49, GP-Wiz40 RotoX | GroovyGameGear | [`devices/GroovyGameGear/README.md`](../devices/GroovyGameGear/README.md) |
+| TOS428 | GRS | below |
+
+## Ways
+
+`Restrictor::Ways` is the full set of positions any restrictor can be asked for. Each board maps the ones it cannot reach onto something it can.
+
+| Value | Meaning |
+|---|---|
+| `invalid` | no rotation, skip the board |
+| `w2` | 2 way horizontal |
+| `w2v` | 2 way vertical |
+| `w4` | 4 way |
+| `w4x` | 4 way diagonal |
+| `w8` | 8 way |
+| `w16` | 16 way |
+| `w49` | 49 way progressive |
+| `analog` | raw analog |
+| `mouse` | mouse emulation |
+| `rotary8` | 8 position rotary |
+| `rotary12` | 12 position rotary |
+
+The list stops at what hardware implements. MAME also knows the half variants, 3 way (half 4) and 5 way (half 8) among others, and a mapped board like the UltraStik360 could express them in a `.um` file. They are left out on purpose: every one of them is played acceptably on its full-way equivalent, and adding them would force every other board to fold them back anyway. Add one only when a board can do something with it that `w4` or `w8` cannot.
+
+Coverage by board:
+
+| Board | Positions it can actually reach |
+|---|---|
+| ServoStik | `w4`, `w8`. Everything narrower folds to `w4`, everything else to `w8` |
+| UltraStik360 | any, through a downloaded 9x9 map file |
+| GP-Wiz49 | `w2`, `w2v`, `w4`, `w4x`, `w8`, `w16`, `w49`, `analog`, `mouse` |
+| GP-Wiz40 RotoX | `rotary8`, `rotary12` only |
+| TOS428 | `w4`, `w8`. Everything narrower folds to `w4`, everything else to `w8` |
+
+Only ServoStik, UltraStik360 and TOS428 move anything physically. The GP-Wiz boards change how the sensor is interpreted.
+
+## Player addressing
+
+`getMaxIds()` is how many restrictors one board controls.
+
+| Board | Max IDs | Addressing |
+|---|---|---|
+| ServoStik | 2 | none; one command moves both, the first player's value wins |
+| UltraStik360 | 1 | one board per stick, board ID selects the board |
+| GP-Wiz49 | 1 | one board per stick |
+| GP-Wiz40 RotoX | 2 | both rotors in one message, separate bits |
+| TOS428 | 4 | player number in the command, 0 addresses all. Only player 1 is really independent, see below |
+
+## TOS428 (GRS)
+
+Serial gate restrictor, four outputs on one board.
+
+| Property | Value |
+|---|---|
+| Transport | serial, `RestrictorSerial` |
+| USB ID for detection | `2341/8036` |
+| Port scan | `/dev/ttyUSB0`-`4` and `/dev/ttyACM0`-`4` |
+| Command | ASCII `setway,<player>,<ways>` |
+| Inter-command delay | 1000 us |
+| Max IDs | 4 |
+
+`<player>` is `'0'` to `'4'` and `<ways>` is `'4'` or `'8'`, both as ASCII digits. Player `'0'` sets every restrictor at once, and `rotate()` uses it whenever more than one player is being set and they all want the same position. Otherwise one command is sent per player.
+
+`2341` is Arduino's vendor ID and `8036` is the Leonardo. Detection matches `PRODUCT=2341/8036` in the port's uevent, so any Leonardo-class board attached at the same time can be picked up by mistake. Set `port` explicitly when that is possible.
+
+Only two gate positions exist in the firmware, so everything below 8 way arrives as 4 way.
+
+### Full command set
+
+Extracted from the vendor's own `libtos428.so` (`SteBuTOS/tos428config-raspi`). Only `setway` is used here.
+
+| Command | Note |
+|---|---|
+| `getway,%i` | |
+| `setway,%i,%s` | way is the string `4` or `8` |
+| `getangle,%i,%s` | angle is per restrictor and per way |
+| `setangle,%i,%s,%i` | fine tunes the gate travel |
+| `getcolor,%s` / `setcolor,%s,%i,%i,%i` | RGB, the board has lighting |
+| `getstartupway` / `setstartupway,%s` | power on position |
+| `getpurpose,%i` / `setpurpose,%i,%s` | |
+| `getscope,%i` / `setscope,%i,%i,%i,%i,%i` | |
+| `getkeycodes,%i,%s` / `setkeycodes,%i,%s,%s,%s,%s` | the board can emit key codes |
+| `dumpeeprom` | dumps stored configuration |
+
+`setangle`, `setcolor`, `setstartupway` and `setkeycodes` are all unused by LEDSpicer and have no equivalent on any other restrictor.
+
+### The board replies, LEDSpicer does not read it
+
+`tos428Cmd` in the vendor library is write, `usleep`, read. The Go implementation reads too and treats any reply other than `ok` as a fatal error. `RestrictorSerial` never reads, so a rejected or misparsed command is silently discarded and `rotate()` reports success either way. This is the diagnostic channel for anything below.
+
+### Only gate 1 is individually addressable
+
+Confirmed on hardware with two gates connected, from both `rotator` and raw serial.
+
+| Command | Reply | Effect |
+|---|---|---|
+| `setway,0,<ways>` | `ok` | every gate moves |
+| `setway,all,<ways>` | `ok` | every gate moves |
+| `setway,1,<ways>` | `ok` | gate 1 moves |
+| `setway,2,<ways>` | `ok` | **nothing moves** |
+| `setway,` 3, 4, a, b, c or d | `ok` | nothing moves |
+
+Nothing addresses gate 2 alone. Every candidate name was tried, numeric and alphabetic. The board is reachable as a whole, or through gate 1, and no other way.
+
+Nothing above the wire is at fault. The format matches `tos428SetWay` in the vendor's own `libtos428.so` byte for byte, `player_map` ids of 1 and 2 are correct and distinct, and `rotate()` picks its broadcast and per-player branches correctly. The board accepts the command and declines to act on it.
+
+Whether that is a firmware defect or a stored per port setting is **not yet established**. The vendor library exposes two per port properties nothing else uses:
+
+| Property | Values | Command |
+|---|---|---|
+| purpose | `restrictor` or `keyboard` | `getpurpose,%i` / `setpurpose,%i,%s` |
+| scope | four values, one per gate | `getscope,%i` / `setscope,%i,%i,%i,%i,%i` |
+
+`tos428GetScope` parses exactly four integers out of the reply, one per gate, which reads as a matrix of which gates a target drives. A port whose purpose is `keyboard`, or whose scope selects no gate, would accept `setway` and move nothing, exactly as observed. Compare `getpurpose,1` against `getpurpose,2` and `getscope,1` against `getscope,2` before calling this a firmware bug.
+
+**The board answers `ok` to a command it does not execute.** Reading the reply, which LEDSpicer does not do, would not have caught this. Reply checking is a diagnostic aid, not a fix.
+
+Consequence: per-player commands cannot drive a cabinet that needs different positions at once. The all-same case is unaffected, because `rotate()` collapses it to one broadcast.
+
+### Working around it
+
+Two gates can still be set independently by ordering the writes so the broadcast lands first and gate 1 is corrected afterwards:
+
+```
+setway,0,<way wanted by gates 2 and up>
+setway,1,<way wanted by gate 1>
+```
+
+Gate 1 moves twice and ends correct, every other gate moves once. This is right for two gates always, and for three or four whenever gates 2 and up agree with each other. It cannot help when three or more gates want three different positions, which the hardware cannot express at all.
+
+`rotate()` does not do this yet.
+
+### getway does not report position
+
+`getway,<n>` returned `8` for every gate at every point during testing, including immediately after a gate had physically moved to 4. Whatever it reports, it is not live position, so it cannot be used to confirm a move or to skip a redundant one.
+
+### Position is tracked in firmware
+
+The board remembers where each gate is and ignores a command asking for the position it already holds. So the redundant-move problem that ServoStik solves with a cache file does not exist here, and no state is kept on the host. It also means a gate moved by hand, out of band, will stay wrong until something asks for a different position.
+
+## Cross-cutting notes
+
+- No restrictor reports its current position back to the host. ServoStik caches it in `~/.config/ledspicer/servostik/last_<profile>.dat` to skip redundant moves; TOS428 tracks it in firmware and needs nothing. Every other board is written unconditionally on each profile change.
+- `boardId` is user-declared and matched to physical wiring, exactly as for devices. ServoStik is the exception: its PID is fixed, so boards are told apart by bus and port position through `isNonBasedId()`.
+- Rotation happens on profile change, not per frame. The serial boards are slow enough that per frame would not work.

--- a/src/utilities/FakeLibUSB.cpp
+++ b/src/utilities/FakeLibUSB.cpp
@@ -30,6 +30,8 @@ bool fakeFailOpen = false;
 
 std::vector<libusb_device*> fakeDevices;
 
+std::vector<FakeTransfer> fakeTransfers;
+
 int libusb_init(libusb_context** ctx) {
 	LogNotice("Using a Fake libusb");
 	if (fakeFailInit) return LIBUSB_ERROR_IO;
@@ -55,12 +57,19 @@ void libusb_free_device_list(libusb_device** list, int) {
 	delete[] list;
 }
 
-int libusb_get_device_descriptor(libusb_device*, libusb_device_descriptor* desc) {
-	// Populate from fake device (assume dev has data; in tests, set it).
-	desc->idVendor  = 0x1234;
-	desc->idProduct = 0xABCD;
-	desc->bcdDevice = 0x40;
+int libusb_get_device_descriptor(libusb_device* dev, libusb_device_descriptor* desc) {
+	*desc = dev->descriptor;
 	return LIBUSB_SUCCESS;
+}
+
+int libusb_get_active_config_descriptor(libusb_device* dev, libusb_config_descriptor** config) {
+	if (not dev->configuration) return LIBUSB_ERROR_NOT_FOUND;
+	*config = const_cast<libusb_config_descriptor*>(dev->configuration);
+	return LIBUSB_SUCCESS;
+}
+
+void libusb_free_config_descriptor(libusb_config_descriptor*) {
+	// Don't free; the configuration is owned by the fake device.
 }
 
 libusb_device *libusb_get_device(libusb_device_handle *dev_handle) {
@@ -102,8 +111,18 @@ int libusb_control_transfer(
 	uint16_t w_length,
 	unsigned int timeout
 ) {
+	// Reads are served from the report descriptor the test gave the device.
+	if (request_type & LIBUSB_ENDPOINT_IN) {
+		const std::vector<uint8_t>& report = handle->associated_dev->reportDescriptor;
+		const uint16_t size = w_length < report.size() ? w_length : report.size();
+		std::copy(report.begin(), report.begin() + size, data);
+		LogDebug("Fake Read: wValue: " + Utility::hex2str(w_value) +
+			" wIndex: " + Utility::hex2str(w_index) + " wLength: " + std::to_string(size));
+		return size;
+	}
 	LogDebug("Fake Transfer: wValue: " + Utility::hex2str(w_value) +
 		" wIndex: " + Utility::hex2str(w_index) + " wLength: " + std::to_string(w_length));
+	fakeTransfers.push_back({w_value, w_index, std::vector<uint8_t>(data, data + w_length)});
 	// Fake success: "transferred" all bytes.
 	return w_length;
 }
@@ -135,8 +154,8 @@ const char* libusb_error_name(int) {
 	return "FAKE_ERROR";
 }
 
-uint8_t libusb_get_bus_number(libusb_device*) {
-	return 1; // stable fake value
+uint8_t libusb_get_bus_number(libusb_device* dev) {
+	return dev->bus;
 }
 
 uint8_t libusb_get_device_address(libusb_device*) {
@@ -144,7 +163,7 @@ uint8_t libusb_get_device_address(libusb_device*) {
 }
 
 int libusb_get_port_numbers(
-	libusb_device* /*dev*/,
+	libusb_device* dev,
 	uint8_t* port_numbers,
 	int port_numbers_len
 ) {
@@ -152,7 +171,8 @@ int libusb_get_port_numbers(
 		return LIBUSB_ERROR_IO;
 	}
 
-	// Fake a simple USB topology: bus → port 1
-	port_numbers[0] = 1;
-	return 1; // number of ports written
+	const int size = static_cast<int>(dev->ports.size()) < port_numbers_len ?
+		static_cast<int>(dev->ports.size()) : port_numbers_len;
+	std::copy(dev->ports.begin(), dev->ports.begin() + size, port_numbers);
+	return size;
 }

--- a/src/utilities/FakeLibUSB.hpp
+++ b/src/utilities/FakeLibUSB.hpp
@@ -27,14 +27,33 @@
 
 // Fake types (minimal stubs for libusb structs).
 struct libusb_context {};
-struct libusb_device {};
+struct libusb_device_descriptor {
+	uint16_t idVendor  = 0x1234;
+	uint16_t idProduct = 0xABCD;
+	uint16_t bcdDevice = 0x40;
+};
+struct libusb_interface_descriptor {
+	uint8_t                     bInterfaceNumber = 0;
+	const unsigned char*        extra            = nullptr;
+	int                         extra_length     = 0;
+};
+struct libusb_interface {
+	const libusb_interface_descriptor* altsetting = nullptr;
+};
+struct libusb_config_descriptor {
+	uint8_t                 bNumInterfaces = 0;
+	const libusb_interface* interface      = nullptr;
+};
+/// Tests populate these; every stub reads the device it was handed instead of a global.
+struct libusb_device {
+	libusb_device_descriptor        descriptor;
+	uint8_t                         bus   = 1;
+	std::vector<uint8_t>            ports {1};
+	const libusb_config_descriptor* configuration = nullptr;
+	std::vector<uint8_t>            reportDescriptor;
+};
 struct libusb_device_handle {
 	libusb_device* associated_dev = nullptr;
-};
-struct libusb_device_descriptor {
-	uint16_t idVendor;
-	uint16_t idProduct;
-	uint16_t bcdDevice;
 };
 
 // Constants (copied from real libusb for compatibility).
@@ -55,8 +74,11 @@ enum {
 	LIBUSB_ERROR_OTHER = -99
 };
 #define LIBUSB_ENDPOINT_OUT        0x00
+#define LIBUSB_ENDPOINT_IN         0x80
 #define LIBUSB_REQUEST_TYPE_CLASS  0x20
 #define LIBUSB_RECIPIENT_INTERFACE 0x01
+
+#define LIBUSB_REQUEST_GET_DESCRIPTOR 0x06
 
 // Log levels (reuse from libusb, but stubbed).
 #define LIBUSB_LOG_LEVEL_NONE    0
@@ -73,12 +95,23 @@ extern bool fakeFailInit;
 extern bool fakeFailOpen;
 extern std::vector<libusb_device*> fakeDevices;  // Pre-populate in tests.
 
+/// One recorded outgoing control transfer.
+struct FakeTransfer {
+	uint16_t             wValue;
+	uint16_t             wIndex;
+	std::vector<uint8_t> data;
+};
+/// Every outgoing transfer, in order, so tests can assert the wire format.
+extern std::vector<FakeTransfer> fakeTransfers;
+
 // Stub function declarations.
 int libusb_init(libusb_context** ctx);
 void libusb_exit(libusb_context* ctx);
 ssize_t libusb_get_device_list(libusb_context* ctx, libusb_device*** list);
 void libusb_free_device_list(libusb_device** list, int unref_devices);
 int libusb_get_device_descriptor(libusb_device* dev, libusb_device_descriptor* desc);
+int libusb_get_active_config_descriptor(libusb_device* dev, libusb_config_descriptor** config);
+void libusb_free_config_descriptor(libusb_config_descriptor* config);
 libusb_device* libusb_get_device(libusb_device_handle* dev_handle);
 int libusb_open(libusb_device* dev, libusb_device_handle** handle);
 int libusb_claim_interface(libusb_device_handle* handle, int interface_number);

--- a/src/utilities/USB.cpp
+++ b/src/utilities/USB.cpp
@@ -62,7 +62,7 @@ void USB::connect() {
 		for (size_t idx = 0; list[idx] != nullptr; ++idx) {
 			libusb_device_descriptor desc;
 			if (libusb_get_device_descriptor(list[idx], &desc) != 0) continue;
-			if (desc.idVendor != getVendor() or desc.idProduct != getProduct()) continue;
+			if (not matchesSignature(desc)) continue;
 
 			Candidate c;
 			c.dev = list[idx];
@@ -90,7 +90,7 @@ void USB::connect() {
 			libusb_device_descriptor desc;
 			libusb_get_device_descriptor(device, &desc);
 
-			if (desc.idVendor == getVendor() and desc.idProduct == getProduct()) {
+			if (matchesSignature(desc)) {
 				// For ID by product only check the vendor and product.
 				if (isProductBasedId()) {
 					break;
@@ -110,13 +110,20 @@ void USB::connect() {
 	libusb_free_device_list(list, 1);
 
 	if (rc == LIBUSB_SUCCESS) {
-		libusb_set_auto_detach_kernel_driver(handle, true);
+		// Without this the kernel HID driver keeps the interface and claiming it fails.
+		const int detach = libusb_set_auto_detach_kernel_driver(handle, true);
+		if (detach != LIBUSB_SUCCESS)
+			LogWarning(
+				"Unable to enable kernel driver auto detach on " +
+				Utility::hex2str(getVendor()) + ":" + Utility::hex2str(getProduct()) +
+				": " + libusb_error_name(detach)
+			);
 		return;
 	}
 
 	throw Error("Failed to open device ")  <<
 			Utility::hex2str(getVendor())  << ":" <<
-			Utility::hex2str(getProduct()) << " id " << getId();
+			Utility::hex2str(getProduct()) << " id " << getId() << notFoundHint();
 }
 
 void USB::disconnect() {
@@ -135,11 +142,20 @@ void USB::disconnect() {
 }
 
 void USB::claimInterface() {
+
 	LogDebug("Claiming interface " + to_string(interface));
-	if (libusb_claim_interface(handle, interface))
-		throw Error("Unable to claim interface to ") <<
-				Utility::hex2str(getVendor()) << ":" <<
-				Utility::hex2str(getProduct());
+
+	const int rc = libusb_claim_interface(handle, interface);
+	if (not rc) return;
+
+	Error error("Unable to claim interface ");
+	error << to_string(interface) << " on " <<
+			Utility::hex2str(getVendor()) << ":" <<
+			Utility::hex2str(getProduct()) << ": " << libusb_error_name(rc);
+	// Devices are claimed before the socket is bound, so a second daemon lands here first.
+	if (rc == LIBUSB_ERROR_BUSY)
+		error << ", another program is using the board, check for a running ledspicerd";
+	throw error;
 }
 
 void USB::closeSession() {
@@ -161,6 +177,14 @@ bool USB::isProductBasedId() const {
 
 bool USB::isNonBasedId() const {
 	return false;
+}
+
+bool USB::matchesSignature(const libusb_device_descriptor& descriptor) const {
+	return descriptor.idVendor == getVendor() and descriptor.idProduct == getProduct();
+}
+
+string USB::notFoundHint() const {
+	return "";
 }
 
 int USB::send(vector<uint8_t>& data) const {

--- a/src/utilities/USB.hpp
+++ b/src/utilities/USB.hpp
@@ -95,6 +95,15 @@ public:
 	virtual bool isNonBasedId() const;
 
 	/**
+	 * Tests an enumerated device against this board USB signature.
+	 * Hardware that encodes more than the board position into the product code overrides this.
+	 *
+	 * @param descriptor the enumerated device descriptor.
+	 * @return true if the device is a candidate for this board.
+	 */
+	virtual bool matchesSignature(const libusb_device_descriptor& descriptor) const;
+
+	/**
 	 * This function will be used to close the USB session,
 	 * need to be called only once when ledspicer exit.
 	 */
@@ -119,6 +128,13 @@ protected:
 	 * Connects to the USB board.
 	 */
 	virtual void connect();
+
+	/**
+	 * Extra explanation appended to the error thrown when the board is not on the bus.
+	 *
+	 * @return the hint, empty when the hardware has nothing to add.
+	 */
+	virtual string notFoundHint() const;
 
 	/**
 	 * Claims the interface.

--- a/tests/src/devices/CMakeLists.txt
+++ b/tests/src/devices/CMakeLists.txt
@@ -20,3 +20,4 @@ add_test_executable(ItemsTest
 )
 
 add_subdirectory(transitions)
+add_subdirectory(Ultimarc)

--- a/tests/src/devices/Ultimarc/CMakeLists.txt
+++ b/tests/src/devices/Ultimarc/CMakeLists.txt
@@ -1,0 +1,15 @@
+# Test the Ultimate I/O board, descriptor driven interface and protocol selection.
+add_test_executable(UltimateTest
+	"${CMAKE_CURRENT_SOURCE_DIR}/UltimateTest.cpp"
+	"${CMAKE_SOURCE_DIR}/src/devices/Ultimarc/Ultimarc.cpp;${CMAKE_SOURCE_DIR}/src/devices/DeviceUSB.cpp;${CMAKE_SOURCE_DIR}/src/devices/Device.cpp;${CMAKE_SOURCE_DIR}/src/devices/Group.cpp;${CMAKE_SOURCE_DIR}/src/devices/Element.cpp;${CMAKE_SOURCE_DIR}/src/utilities/USB.cpp;${CMAKE_SOURCE_DIR}/src/utilities/FakeLibUSB.cpp;${CMAKE_SOURCE_DIR}/src/utilities/Color.cpp;${CMAKE_SOURCE_DIR}/src/utilities/Time.cpp;${CMAKE_SOURCE_DIR}/src/utilities/Log.cpp;${CMAKE_SOURCE_DIR}/src/utilities/Utility.cpp"
+	""
+)
+target_compile_definitions(UltimateTest PRIVATE DRY_RUN=1)
+
+# Test PacLed64, guarding the pair stream that Ultimate now shares.
+add_test_executable(PacLed64Test
+	"${CMAKE_CURRENT_SOURCE_DIR}/PacLed64Test.cpp"
+	"${CMAKE_SOURCE_DIR}/src/devices/Ultimarc/FF00SharedCode.cpp;${CMAKE_SOURCE_DIR}/src/devices/Ultimarc/Ultimarc.cpp;${CMAKE_SOURCE_DIR}/src/devices/DeviceUSB.cpp;${CMAKE_SOURCE_DIR}/src/devices/Device.cpp;${CMAKE_SOURCE_DIR}/src/devices/Group.cpp;${CMAKE_SOURCE_DIR}/src/devices/Element.cpp;${CMAKE_SOURCE_DIR}/src/utilities/USB.cpp;${CMAKE_SOURCE_DIR}/src/utilities/FakeLibUSB.cpp;${CMAKE_SOURCE_DIR}/src/utilities/Color.cpp;${CMAKE_SOURCE_DIR}/src/utilities/Time.cpp;${CMAKE_SOURCE_DIR}/src/utilities/Log.cpp;${CMAKE_SOURCE_DIR}/src/utilities/Utility.cpp"
+	""
+)
+target_compile_definitions(PacLed64Test PRIVATE DRY_RUN=1)

--- a/tests/src/devices/Ultimarc/PacLed64Test.cpp
+++ b/tests/src/devices/Ultimarc/PacLed64Test.cpp
@@ -1,0 +1,111 @@
+/* -*- Mode: C; indent-tabs-mode: t; c-basic-offset: 4; tab-width: 4 -*-  */
+/**
+ * @file      PacLed64Test.cpp
+ * @since     Jul 27, 2026
+ * @author    Patricio A. Rossi (MeduZa)
+ *
+ * @copyright Copyright © 2018 - 2026 Patricio A. Rossi (MeduZa)
+ *
+ * @copyright LEDSpicer is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @copyright LEDSpicer is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * @copyright You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <gtest/gtest.h>
+
+/*
+ * The source, not the header: deviceFactory() defines createDevice and destroyDevice in every
+ * translation unit that includes PacLed64.hpp, so the board has to be built into this one.
+ */
+#include "devices/Ultimarc/PacLed64.cpp"
+
+using namespace LEDSpicer::Devices::Ultimarc;
+using namespace LEDSpicer::Utilities;
+
+/// Guards the wire format of the pair stream that moved to Ultimarc::transferPairs().
+class TestPacLed64 : public PacLed64 {
+public:
+	TestPacLed64(StringUMap& options) : PacLed64(options) {}
+
+	using PacLed64::connect;
+	using PacLed64::disconnect;
+};
+
+class PacLed64Test : public ::testing::Test {
+
+protected:
+
+	StringUMap options;
+
+	void SetUp() override {
+		fakeFailInit = false;
+		fakeFailOpen = false;
+		for (auto device : fakeDevices) delete device;
+		fakeDevices.clear();
+		fakeTransfers.clear();
+		options.clear();
+		options["boardId"] = "1";
+
+		libusb_device* device = new libusb_device();
+		device->descriptor.idVendor  = ULTIMARC_VENDOR;
+		device->descriptor.idProduct = PAC_LED64_PRODUCT;
+		fakeDevices.push_back(device);
+
+		Log::logToStdTerm(true);
+		Log::setLogLevel(LOG_ERR);
+	}
+
+	void TearDown() override {
+		USB::closeSession();
+	}
+};
+
+TEST_F(PacLed64Test, TransferStreamsPairsAfterAReset) {
+
+	TestPacLed64 board(options);
+	board.connect();
+	board.setLed(0, 0x11);
+	board.setLed(1, 0x22);
+	board.setLed(2, 0x33);
+
+	fakeTransfers.clear();
+	board.transfer();
+
+	// One reset plus one two byte message per pair, unchanged from before the helper moved.
+	ASSERT_EQ(fakeTransfers.size(), 1 + PAC_LED64_LEDS / 2);
+
+	const vector<uint8_t> reset {0xFE, 0}, first {0x11, 0x22}, second {0x33, 0};
+	EXPECT_EQ(fakeTransfers[0].data, reset);
+	EXPECT_EQ(fakeTransfers[1].data, first);
+	EXPECT_EQ(fakeTransfers[2].data, second);
+	board.disconnect();
+}
+
+TEST_F(PacLed64Test, ResetLedsSetsTheRampThenEveryLedOff) {
+
+	TestPacLed64 board(options);
+	board.connect();
+
+	fakeTransfers.clear();
+	board.resetLeds();
+
+	const vector<uint8_t> ramp {0xC0, 0}, off {0x80, 0};
+	ASSERT_EQ(fakeTransfers.size(), 2);
+	EXPECT_EQ(fakeTransfers[0].data, ramp);
+	EXPECT_EQ(fakeTransfers[1].data, off);
+	board.disconnect();
+}
+
+int main(int argc, char **argv) {
+	::testing::InitGoogleTest(&argc, argv);
+	return RUN_ALL_TESTS();
+}

--- a/tests/src/devices/Ultimarc/UltimateTest.cpp
+++ b/tests/src/devices/Ultimarc/UltimateTest.cpp
@@ -1,0 +1,305 @@
+/* -*- Mode: C; indent-tabs-mode: t; c-basic-offset: 4; tab-width: 4 -*-  */
+/**
+ * @file      UltimateTest.cpp
+ * @since     Jul 27, 2026
+ * @author    Patricio A. Rossi (MeduZa)
+ *
+ * @copyright Copyright © 2018 - 2026 Patricio A. Rossi (MeduZa)
+ *
+ * @copyright LEDSpicer is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @copyright LEDSpicer is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * @copyright You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <gtest/gtest.h>
+
+/*
+ * The source, not the header: deviceFactory() defines createDevice and destroyDevice in every
+ * translation unit that includes Ultimate.hpp, so the board has to be built into this one.
+ */
+#include "devices/Ultimarc/Ultimate.cpp"
+
+using namespace LEDSpicer::Devices::Ultimarc;
+using namespace LEDSpicer::Utilities;
+
+/// Exposes the parts of the board that only the connection sequence would reach.
+class TestUltimate : public Ultimate {
+public:
+	TestUltimate(StringUMap& options) : Ultimate(options) {}
+
+	using Ultimate::matchesSignature;
+	using Ultimate::notFoundHint;
+	using Ultimate::connect;
+	using Ultimate::disconnect;
+	using Ultimate::afterConnect;
+	using Ultimate::afterClaimInterface;
+	using Ultimate::LEDs;
+
+	uint8_t getInterface() const { return interface; }
+
+	bool isFast() const { return hasFastLedReport; }
+};
+
+/// A board descriptor with the product code the mode and the board position produce.
+libusb_device* board(uint16_t product, uint8_t interfaces = 3, uint8_t usagePage = 1) {
+
+	static const uint8_t hidDescriptor[] {
+		9, HID_DESCRIPTOR, 0x11, 0x01, 0, 1, HID_REPORT_DESCRIPTOR, 4, 0
+	};
+	static libusb_interface_descriptor altsettings[4];
+	static libusb_interface           interfaceList[4];
+	static libusb_config_descriptor   configuration;
+
+	libusb_device* device = new libusb_device();
+	device->descriptor.idVendor  = ULTIMARC_VENDOR;
+	device->descriptor.idProduct = product;
+
+	for (uint8_t c = 0; c < interfaces; ++c) {
+		altsettings[c].bInterfaceNumber = c;
+		altsettings[c].extra            = hidDescriptor;
+		altsettings[c].extra_length     = sizeof(hidDescriptor);
+		interfaceList[c].altsetting     = &altsettings[c];
+	}
+	configuration.bNumInterfaces = interfaces;
+	configuration.interface      = interfaceList;
+	device->configuration        = &configuration;
+
+	// Usage Page (one byte of data), then an unrelated two byte item.
+	device->reportDescriptor = {HID_ITEM_USAGE_PAGE | 1, usagePage, 0x0A, 0, 0};
+
+	return device;
+}
+
+class UltimateTest : public ::testing::Test {
+
+protected:
+
+	StringUMap options;
+
+	void SetUp() override {
+		fakeFailInit = false;
+		fakeFailOpen = false;
+		for (auto device : fakeDevices) delete device;
+		fakeDevices.clear();
+		fakeTransfers.clear();
+		options.clear();
+		Log::logToStdTerm(true);
+		Log::setLogLevel(LOG_ERR);
+	}
+
+	void TearDown() override {
+		USB::closeSession();
+	}
+};
+
+TEST_F(UltimateTest, MatchesBoardOneInEitherMode) {
+
+	options["boardId"] = "1";
+	TestUltimate ultimate(options);
+
+	libusb_device_descriptor descriptor;
+	descriptor.idVendor = ULTIMARC_VENDOR;
+
+	// Board 1 keyboard, board 1 Dinput.
+	descriptor.idProduct = 0x0410;
+	EXPECT_TRUE(ultimate.matchesSignature(descriptor));
+	descriptor.idProduct = 0x0412;
+	EXPECT_TRUE(ultimate.matchesSignature(descriptor));
+
+	// Board 2 in either mode is not board 1.
+	descriptor.idProduct = 0x0411;
+	EXPECT_FALSE(ultimate.matchesSignature(descriptor));
+	descriptor.idProduct = 0x0413;
+	EXPECT_FALSE(ultimate.matchesSignature(descriptor));
+}
+
+TEST_F(UltimateTest, MatchesBoardTwoInEitherMode) {
+
+	options["boardId"] = "2";
+	TestUltimate ultimate(options);
+
+	libusb_device_descriptor descriptor;
+	descriptor.idVendor = ULTIMARC_VENDOR;
+
+	descriptor.idProduct = 0x0411;
+	EXPECT_TRUE(ultimate.matchesSignature(descriptor));
+	descriptor.idProduct = 0x0413;
+	EXPECT_TRUE(ultimate.matchesSignature(descriptor));
+
+	descriptor.idProduct = 0x0410;
+	EXPECT_FALSE(ultimate.matchesSignature(descriptor));
+	descriptor.idProduct = 0x0412;
+	EXPECT_FALSE(ultimate.matchesSignature(descriptor));
+}
+
+TEST_F(UltimateTest, RejectsForeignDevices) {
+
+	options["boardId"] = "1";
+	TestUltimate ultimate(options);
+
+	libusb_device_descriptor descriptor;
+
+	// The Xbox 360 controller the board turns into under Xinput.
+	descriptor.idVendor  = 0x045E;
+	descriptor.idProduct = 0x028E;
+	EXPECT_FALSE(ultimate.matchesSignature(descriptor));
+
+	// Another Ultimarc board, outside the block.
+	descriptor.idVendor  = ULTIMARC_VENDOR;
+	descriptor.idProduct = 0x1401;
+	EXPECT_FALSE(ultimate.matchesSignature(descriptor));
+
+	// Just past the end of the block.
+	descriptor.idProduct = 0x0414;
+	EXPECT_FALSE(ultimate.matchesSignature(descriptor));
+}
+
+TEST_F(UltimateTest, RejectsBoardIdBeyondTheHardware) {
+	// The two board block leaves no room for the boardId 3 workaround from issue 16.
+	options["boardId"] = "3";
+	EXPECT_THROW({TestUltimate board(options);}, Error);
+}
+
+TEST_F(UltimateTest, XinputHintOnFailureToFind) {
+
+	options["boardId"] = "1";
+	TestUltimate ultimate(options);
+
+	try {
+		ultimate.connect();
+		FAIL() << "connect() should not find a board";
+	}
+	catch (Error& e) {
+		EXPECT_NE(e.getMessage().find("Xinput"), string::npos);
+	}
+}
+
+TEST_F(UltimateTest, KeyboardModeUsesTheThirdInterface) {
+
+	options["boardId"] = "1";
+	TestUltimate ultimate(options);
+	fakeDevices.push_back(board(0x0410, 3));
+
+	ultimate.connect();
+	ultimate.afterConnect();
+	EXPECT_EQ(ultimate.getInterface(), 2);
+	ultimate.disconnect();
+}
+
+TEST_F(UltimateTest, DinputModeUsesTheFourthInterface) {
+
+	// The regression from issue 16: the gamepad adds an interface and the LEDs move behind it.
+	options["boardId"] = "1";
+	TestUltimate ultimate(options);
+	fakeDevices.push_back(board(0x0412, 4));
+
+	ultimate.connect();
+	ultimate.afterConnect();
+	EXPECT_EQ(ultimate.getInterface(), 3);
+	ultimate.disconnect();
+}
+
+TEST_F(UltimateTest, DetectsTheFastReportFromTheUsagePage) {
+
+	options["boardId"] = "1";
+	TestUltimate fast(options);
+	fakeDevices.push_back(board(0x0410, 3, IPAC_ULTIMATE_FAST_PAGE));
+	fast.connect();
+	fast.afterConnect();
+	fast.afterClaimInterface();
+	EXPECT_TRUE(fast.isFast());
+	fast.disconnect();
+
+	for (auto device : fakeDevices) delete device;
+	fakeDevices.clear();
+
+	TestUltimate paired(options);
+	fakeDevices.push_back(board(0x0410, 3, 1));
+	paired.connect();
+	paired.afterConnect();
+	paired.afterClaimInterface();
+	EXPECT_FALSE(paired.isFast());
+	paired.disconnect();
+}
+
+TEST_F(UltimateTest, FastReportSendsEverythingInOnePacket) {
+
+	options["boardId"] = "1";
+	TestUltimate ultimate(options);
+	fakeDevices.push_back(board(0x0410, 3, IPAC_ULTIMATE_FAST_PAGE));
+
+	ultimate.connect();
+	ultimate.afterConnect();
+	ultimate.afterClaimInterface();
+	ultimate.setLed(0, 0x11);
+	ultimate.setLed(1, 0x22);
+
+	fakeTransfers.clear();
+	ultimate.transfer();
+
+	ASSERT_EQ(fakeTransfers.size(), 1);
+	ASSERT_EQ(fakeTransfers[0].data.size(), IPAC_ULTIMATE_LEDS + 1);
+	EXPECT_EQ(fakeTransfers[0].data[0], IPAC_ULTIMATE_FAST_REPORT);
+	EXPECT_EQ(fakeTransfers[0].data[1], 0x11);
+	EXPECT_EQ(fakeTransfers[0].data[2], 0x22);
+	ultimate.disconnect();
+}
+
+TEST_F(UltimateTest, PairedReportStreamsFortyEightPairsAfterAReset) {
+
+	options["boardId"] = "1";
+	TestUltimate ultimate(options);
+	fakeDevices.push_back(board(0x0410, 3, 1));
+
+	ultimate.connect();
+	ultimate.afterConnect();
+	ultimate.afterClaimInterface();
+	ultimate.setLed(0, 0x11);
+	ultimate.setLed(1, 0x22);
+
+	fakeTransfers.clear();
+	ultimate.transfer();
+
+	// One reset plus one message per pair.
+	ASSERT_EQ(fakeTransfers.size(), 1 + IPAC_ULTIMATE_LEDS / 2);
+
+	const vector<uint8_t> reset {0x03, 0xFE, 0, 0, 0}, first {0x03, 0x11, 0x22, 0, 0};
+	EXPECT_EQ(fakeTransfers[0].data, reset);
+	EXPECT_EQ(fakeTransfers[1].data, first);
+	ultimate.disconnect();
+}
+
+TEST_F(UltimateTest, ResetLedsCarriesTheCommandInTheSecondByte) {
+
+	options["boardId"] = "1";
+	TestUltimate ultimate(options);
+	fakeDevices.push_back(board(0x0410, 3, IPAC_ULTIMATE_FAST_PAGE));
+
+	ultimate.connect();
+	ultimate.afterConnect();
+	ultimate.afterClaimInterface();
+
+	fakeTransfers.clear();
+	ultimate.resetLeds();
+
+	// Off ramp speed, then every LED to intensity zero.
+	const vector<uint8_t> ramp {0x03, 0xC0, 0, 0, 0}, off {0x03, 0x80, 0, 0, 0};
+	ASSERT_EQ(fakeTransfers.size(), 2);
+	EXPECT_EQ(fakeTransfers[0].data, ramp);
+	EXPECT_EQ(fakeTransfers[1].data, off);
+	ultimate.disconnect();
+}
+
+int main(int argc, char **argv) {
+	::testing::InitGoogleTest(&argc, argv);
+	return RUN_ALL_TESTS();
+}

--- a/tests/src/utilities/USBTest.cpp
+++ b/tests/src/utilities/USBTest.cpp
@@ -39,11 +39,37 @@ public:
 	using USB::transferToConnection;
 	using USB::transferFromConnection;
 
+	using USB::matchesSignature;
+	using USB::notFoundHint;
+
 	virtual uint16_t getVendor() const override { return 0x1234; }
 	virtual uint16_t getProduct() const override { return 0xABCD; }
 	virtual void afterConnect() override {}
 	virtual void afterClaimInterface() override {}
 };
+
+/// A board whose product code carries more than the board position, like the Ultimate I/O.
+class RangeUSB : public MockUSB {
+public:
+	using MockUSB::MockUSB;
+
+	bool matchesSignature(const libusb_device_descriptor& descriptor) const override {
+		return descriptor.idVendor == getVendor() and
+			descriptor.idProduct >= 0xABCD and descriptor.idProduct <= 0xABD0;
+	}
+
+	string notFoundHint() const override { return ", check the board mode"; }
+};
+
+/// Builds a fake board with an explicit descriptor and bus position.
+libusb_device* fakeBoard(uint16_t vendor, uint16_t product, uint8_t bus = 1, uint8_t port = 1) {
+	libusb_device* device = new libusb_device();
+	device->descriptor.idVendor  = vendor;
+	device->descriptor.idProduct = product;
+	device->bus                  = bus;
+	device->ports                = {port};
+	return device;
+}
 
 class USBTest : public ::testing::Test {
 
@@ -157,6 +183,56 @@ TEST_F(USBTest, CloseSession) {
 	USB::closeSession();
 	string output = testing::internal::GetCapturedStdout();
 	EXPECT_TRUE(output.find("Closing USB session") != string::npos);
+}
+
+TEST_F(USBTest, MatchesSignatureDefaultsToVendorAndProduct) {
+
+	MockUSB usb(0x0200, 0, 1, 5);
+	libusb_device_descriptor descriptor;
+
+	descriptor.idVendor  = 0x1234;
+	descriptor.idProduct = 0xABCD;
+	EXPECT_TRUE(usb.matchesSignature(descriptor));
+
+	descriptor.idProduct = 0xABCE;
+	EXPECT_FALSE(usb.matchesSignature(descriptor));
+
+	descriptor.idVendor  = 0x1235;
+	descriptor.idProduct = 0xABCD;
+	EXPECT_FALSE(usb.matchesSignature(descriptor));
+
+	EXPECT_TRUE(usb.notFoundHint().empty());
+}
+
+TEST_F(USBTest, ConnectFindsADeviceThroughAnOverriddenSignature) {
+
+	// The only board on the bus carries a product code the default rule would reject.
+	fakeDevices.push_back(fakeBoard(0x1234, 0xABCF));
+
+	RangeUSB usb(0x0200, 0, 1, 5);
+	usb.connect();
+	usb.disconnect();
+}
+
+TEST_F(USBTest, ConnectSkipsDevicesTheSignatureRejects) {
+
+	fakeDevices.push_back(fakeBoard(0x1234, 0x0001));
+	fakeDevices.push_back(fakeBoard(0x9999, 0xABCD));
+
+	MockUSB usb(0x0200, 0, 1, 5);
+	EXPECT_THROW(usb.connect(), Error);
+}
+
+TEST_F(USBTest, NotFoundHintIsAppendedToTheError) {
+
+	RangeUSB usb(0x0200, 0, 1, 5);
+	try {
+		usb.connect();
+		FAIL() << "connect() should not find a board";
+	}
+	catch (Error& e) {
+		EXPECT_NE(e.getMessage().find("check the board mode"), string::npos);
+	}
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
descriptors instead of inference

Task-Url: https://github.com/meduzapat/LEDSpicer/issues/128

Three facts were derived from values that do not carry them. All three were wrong on current firmware.

- **Product code.** `getProduct()` computed the PID from `boardId`. The `0x0410`-`0x0413` block encodes the board in the low bit and the operating mode in the high bit. New `USB::matchesSignature()` virtual decodes the board back out and accepts either mode; `IPAC_ULTIMAGE_MAX_BOARDS` drops 4 → 2, the count the hardware actually supports. Retires the `boardId="3"` workaround from #16.
- **LED interface.** `afterConnect()` picked it from `bcdDevice & 0x40`, a bit that only distinguishes the 1.3x/1.4x firmware naming and cannot see a runtime mode switch. It now reads the active config descriptor and takes the last interface: 2 in keyboard mode, 3 in Dinput.
- **Transfer protocol.** `transfer()` always sent the 97-byte report; boards without the usage-page-6 collection have no such report and dropped the write. The LED interface's HID report descriptor is now read once after claiming, and `transfer()` dispatches to the paired stream when the collection is absent. The pair loop moved from `FF00SharedCode` to `Ultimarc::transferPairs()`; report framing stays per board, only byte order is shared.
- **`ULTIMAGE_MSG` bug.** Carried command and value in bytes 3-4 while the board reads them from 1-2, so `resetLeds()` had never done anything. Confirmed against PacDriveSDK, Ultimarc-linux and QtPyUltimarc, which all agree on `[0x03, command, value, 0, 0]`.
- **Xinput.** New `USB::notFoundHint()` virtual; in Xinput the board enumerates as `045e:028e` and has no LED interface, so the not-found error now names that as the likely cause.

- `claimInterface()` discarded the libusb error code, so BUSY, ACCESS and NOT_SUPPORTED were indistinguishable. It now names the interface and the error, and calls out `LIBUSB_ERROR_BUSY` as a probable second daemon, since devices are claimed before the socket is bound.
- `libusb_set_auto_detach_kernel_driver()`'s result was ignored; a failure now warns.

- `FakeLibUSB` gives every fake device its own descriptors, configuration and report descriptor, and records outgoing transfers, so wire formats are testable without hardware.
- New `UltimateTest` (11 cases): PID decode per board and mode, interface selection in both modes, fast-report detection, both transfer paths, message layout.
- New `PacLed64Test` (2 cases): guards that the extracted pair helper did not change PacLed64/NanoLed output.
- `USBTest` extended for `matchesSignature()` and `notFoundHint()`. 29/29 pass, clean under `ENABLE_DRY_RUN=ON` and against real libusb.

One `README.md` per vendor directory, covering every model including the restrictors, which share a vendor rather than a source tree. Sourced from this tree plus PacDriveSDK, Ultimarc-linux, QtPyUltimarc, libhowler, the vendor's own `libtos428.so`, and `lsusb -v` from real hardware. Inferred facts are marked as such.

Gaps recorded: the PacDrive marker byte that differs from the SDK, the unreachable pre-2015 UltraStik360, Howler endpoint macros named from the device's point of view, LED-Wiz pulse modes and the solid-on value that LEDSpicer cannot reach, the Raspberry Pi fixed pin offset, and a missing comma in `ADALIGHT_PRODUCT_IDS` that concatenates two ids into one unmatchable string.

- Interface selection validated: `uses interface 2 of 3` in keyboard mode.
- PacLed64 publishes a single interface numbered 0, so passing 0 is correct and `PAC_LED64_INTERFACE`/`NANO_LED_INTERFACE` are dead constants, not the discrepancy first recorded.
- Ultimate I/O reports `bcdDevice 0.49`, not a `1.5x` value, so `bcdDevice` does not map onto the published firmware table at all. The old test landed on interface 2 by luck.
- PacDrive board 1 reports `bcdDevice 0.01`, confirming the `bcdDevice == boardId` tiebreak compares BCD against decimal, safe only while `boardId` ≤ 9.
- No Ultimarc LED board publishes an OUT endpoint; control transfers are the only path.

Traced a reported inability to set per-player positions. **Not a LEDSpicer defect.** `setway,0` and `setway,all` broadcast, `setway,1` moves gate 1, and every other target, numeric or alphabetic, returns `ok` and does nothing. The wire format matches the vendor's own `libtos428.so` byte for byte, the `player_map` ids were correct, and `rotate()` picks its branches correctly. Also found: the board returns `ok` for commands it does not execute, and `getway` does not report live position.

Extracted the full undocumented command set from the vendor library, including two per-port properties nothing uses, `purpose` (`restrictor`/`keyboard`) and `scope` (four flags per gate), either of which could explain the behaviour; attribution left open pending a `getpurpose`/`getscope` comparison. A workaround is documented but not implemented: broadcast the value the later gates want, then correct gate 1.

`IPAC_ULTIMAGE_MAX_BOARDS` 4 → 2 rejects configs carrying #16's `boardId="3"` workaround at load. Needs a release note and a matching clamp in LEDSpicerUI.

Every run so far stopped at the claim, so `afterClaimInterface()` has never executed: the report-descriptor probe, `hasFastLedReport`, both LED paths, and the corrected `resetLeds()` remain untested, as does the Dinput regression from #16.